### PR TITLE
Audit that git-seekrets works

### DIFF
--- a/audit/laptop.bash
+++ b/audit/laptop.bash
@@ -1,0 +1,17 @@
+#!/bin/bash -euo pipefail
+
+BRANCH=pdb/portable-test # set to 'master' when merged
+
+tempname=`basename $0`
+TMPDIR=`mktemp -d /tmp/${tempname}.XXXXXX`
+if [ $? -ne 0 ]; then
+  echo "$0: Can't create temp dir, $TMPDIR, exiting..."
+  exit 1
+fi
+
+for f in seekrets.bats test_helper.bash; do
+  curl -s -o $TMPDIR/$f https://raw.githubusercontent.com/18F/laptop/$BRANCH/test/$f
+done
+
+export LOCAL_AUDIT=true
+bats --tap $TMPDIR/seekrets.bats


### PR DESCRIPTION
## Changes proposed in this pull request:

This is a WIP, if the upstream PR is accepted, we'll need to change BRANCH to `master`.

To test, clone, checkout the right branch, and run `laptop.bash`:

```
10:58 $ git co pdb/git-seekret-audit
Branch 'pdb/git-seekret-audit' set up to track remote branch 'pdb/git-seekret-audit' from 'origin'.
Switched to a new branch 'pdb/git-seekret-audit'
✔ ~/tmp/cg-scripts [pdb/git-seekret-audit|✔]
10:58 $ git pull
Already up to date.
✔ ~/tmp/cg-scripts [pdb/git-seekret-audit|✔]
10:58 $ cd audit/
✔ ~/tmp/cg-scripts/audit [pdb/git-seekret-audit|✔]
10:58 $ ./laptop.bash
1..20
ok 1 no args gives usage instructions
ok 2 option --version prints version number
ok 3 config command with no options shows config
ok 4 rules command with no options gives a listing of rules
ok 5 git-seekrets does find aws secrets in test repo
ok 6 git-seekrets does find aws accounts in test repo
ok 7 git-seekrets does find aws access keys in test repo
ok 8 git-seekrets does not find newrelic keys as aws keys in test repo
ok 9 git-seekrets does find newrelic secrets in test repo
ok 10 git-seekrets does not find newrelic false positives in test repo
ok 11 git-seekrets only matches newrelic secrets in test repo
ok 12 git-seekrets does find mandrill keys in test repo
ok 13 git-seekrets does not find mandrill key false positives in test repo
ok 14 git-seekrets does find mandrill passwords in test repo
ok 15 git-seekrets does not find mandrill password false positives in test repo
ok 16 git-seekrets does find mandrill usernames in test repo
ok 17 git-seekrets does find slack api token in test repo
ok 18 git-seekrets does not find secrets in test repo
ok 19 git-seekrets can disable all rulesets
ok 20 git-seekrets can enable all rulesets
```
-

## security considerations

When running `laptop.bash` we'll be downloading code from 18F github repo `laptop` and running it locally. Since the repo is controlled by TTS, I don't see any risks that don't outweigh the benefit of ensuring we have `git-seekrets` working locally.
