### PR TITLE
Added some notes in the usage section of admin scripts.

### DIFF
--- a/make-cf-admin.sh
+++ b/make-cf-admin.sh
@@ -9,6 +9,8 @@ if [ "$#" -lt 1 ]; then
   echo
   echo "  Options:"
   echo "     -r    :    Remove the user instead of add"
+  echo 
+  echo "  Be sure to run ./cg-scripts/uaa/login.sh prior to executing this script"
   echo
   exit 1;
 fi

--- a/validate-admins.sh
+++ b/validate-admins.sh
@@ -6,6 +6,10 @@ if [ "$#" -ne 2 ]; then
   echo "   ./validate-admins.sh <uaa-target> <uaa-admin-client-secret>"
   echo
   echo "   EX:  ./validate-admins.sh login.fr.cloud.gov S3c4Et"
+  echo 
+  echo "   Obtain uaa-admin-client-secret by running:"
+  echo 
+  echo "   credhub get -n \"/bosh/cf-{environment-name}/uaa_admin_client_secret\" | grep value | sed -r 's/value: //g'"
   echo
     exit 1
 fi


### PR DESCRIPTION
## Changes proposed in this pull request:
- Added a note about logging in to UAA the jiumpbox before running `make-cf-admins.sh`
- Added a note about getting an `uaa-admin-client-secret` when using `validate-admins.sh`

## security considerations
None. Adding usage notes to existing scripts.
