### PR TITLE
add script to manage global_auditor permissions

### DIFF
--- a/make-cf-global_auditor.sh
+++ b/make-cf-global_auditor.sh
@@ -33,7 +33,7 @@ if ! hash uaac 2>/dev/null; then
   gem install cf-uaac
 fi
 
-declare -a groups=("cloud_controller.global_auditor" "uaa.user" "scim.read" "admin_ui.user")
+declare -a groups=("cloud_controller.global_auditor" "scim.read" "admin_ui.user")
 if $REMOVE; then
   for group in ${groups[@]}
   do

--- a/make-cf-global_auditor.sh
+++ b/make-cf-global_auditor.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -e
+
+if [ "$#" -lt 1 ]; then
+  echo
+  echo "Usage:"
+  echo "  $ ./make-cf-global_auditor.sh [-r] <EMAIL_ADDRESS>"
+  echo
+  echo "  Options:"
+  echo "     -r    :    Remove the user instead of add"
+  echo 
+  echo "  Be sure to run ./cg-scripts/uaa/login.sh prior to executing this script"
+  echo
+  exit 1;
+fi
+USER=$BASH_ARGV
+REMOVE=false
+
+while getopts ":r" opt; do
+  case $opt in
+    r)
+      REMOVE=true
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1;
+      ;;
+  esac
+done
+
+if ! hash uaac 2>/dev/null; then
+  gem install cf-uaac
+fi
+
+declare -a groups=("cloud_controller.global_auditor" "uaa.user" "scim.read" "admin_ui.user")
+if $REMOVE; then
+  for group in ${groups[@]}
+  do
+    echo -n "Removing user from group ${group}... "
+    uaac member delete "${group}" "${USER}" || true
+  done
+else
+  for group in ${groups[@]}
+  do
+    echo -n "Adding user to group ${group}... "
+    uaac member add "${group}" "${USER}" || true
+  done
+fi
+
+echo "DONE"


### PR DESCRIPTION
## Changes proposed in this pull request:

Attempts to set the correct scopes for a "global_auditor" role. This role should be able to see everything except secrets in CF and use Stratos and the Admin UI to view information.

## security considerations

This replaces the use of admin access for non-admin users.
