### PR TITLE
Add global_auditor check to validate-admins.sh

### DIFF
--- a/validate-admins.sh
+++ b/validate-admins.sh
@@ -9,7 +9,7 @@ if [ "$#" -ne 2 ]; then
   echo 
   echo "   Obtain uaa-admin-client-secret by running:"
   echo 
-  echo "   credhub get -n \"/bosh/cf-{environment-name}/uaa_admin_client_secret\" | grep value | sed -r 's/value: //g'\"
+  echo "   credhub get -n \"/bosh/cf-{environment-name}/uaa_admin_client_secret\" | grep value | sed -r 's/value: //g'"
   echo
     exit 1
 fi

--- a/validate-admins.sh
+++ b/validate-admins.sh
@@ -9,7 +9,7 @@ if [ "$#" -ne 2 ]; then
   echo 
   echo "   Obtain uaa-admin-client-secret by running:"
   echo 
-  echo "   credhub get -n \"/bosh/cf-{environment-name}/uaa_admin_client_secret\" | grep value | sed -r 's/value: //g'"
+  echo "   credhub get -n \"/bosh/cf-{environment-name}/uaa_admin_client_secret\" | grep value | sed -r 's/value: //g'\"
   echo
     exit 1
 fi
@@ -24,6 +24,11 @@ done
 
 echo -e "\n\nadmins for cloud_controller (cf)\n"
 for uuid in $(uaac groups -a members "displayName eq 'cloud_controller.admin'" | grep value | awk '{print $2}'); do 
+    uaac users -a username "id eq '${uuid}'" | grep username | awk '{print $2}'
+done
+
+echo -e "\n\nadmins for global_auditor (cf)\n"
+for uuid in $(uaac groups -a members "displayName eq 'cloud_controller.global_auditor'" | grep value | awk '{print $2}'); do 
     uaac users -a username "id eq '${uuid}'" | grep username | awk '{print $2}'
 done
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add logic to include list of global auditors in the `validate-admins.sh` script
- This change is needed to support work [outlined in this issue](https://github.com/cloud-gov/private/issues/256).

## security considerations
Will help facilitate periodic checks of staff privileges. 
