### PR TITLE
Update the activate and suspend org scripts

### DIFF
--- a/activate-org.sh
+++ b/activate-org.sh
@@ -12,6 +12,7 @@ if [ "$#" -ne 1 ]; then
   echo "Usage:"
   echo "   ./activate-org.sh <org name>"
   echo
+
   exit 1
 fi
 
@@ -25,6 +26,7 @@ if [ "$cf_version" -lt "$min_cf_version" ]; then
   echo "You must update your cf CLI to at least version 7."
   echo "Please run: brew update && brew upgrade cf-cli@7"
   echo
+
   exit 1
 fi
 

--- a/activate-org.sh
+++ b/activate-org.sh
@@ -31,22 +31,15 @@ if [ "$cf_version" -lt "$min_cf_version" ]; then
 fi
 
 org_name=$1
-GUID=$(cf org "${org_name}" --guid)
+org_guid=$(cf org "${org_name}" --guid)
 
 # Set the organization to not be suspended.
-cf curl "/v3/organizations/${GUID}" -X PATCH -d '{"suspended": false}'
+cf curl "/v3/organizations/${org_guid}" -X PATCH -d '{"suspended": false}'
 
-cf target -o "${org_name}"
-
-# Space names can contain spaces, so a for loop won't work as it'll break to
-# the next line upon the first whitespace character it reaches, not just a
-# newline character.  A while loop processes a whole line.
-cf spaces | tail -n +4 | while read -r space; do
-  cf t -s "${space}" > /dev/null
-
-  # The output of running `cf apps` includes more information than just the
-  # application name, which is the only thing we need.
-  for application in $(cf apps | tail -n +4 | awk '{ print $1 }'); do
-    cf start "${application}"
-  done
-done
+# Display a note reminding the platform operator to inform the business unit or
+# customer directly to restart their own apps, as we don't keep track of what
+# was running prior to suspending an organization.
+echo
+echo "Organization ${org_name} has been reactivated."
+echo "Please notify the customer that they must restart their applications."
+echo

--- a/activate-org.sh
+++ b/activate-org.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+# Activates an organization by setting its suspended status to false and starts
+# all stopped applications in all spaces of the organization.
+
+# Requires cf CLI version 7+ to work.
+
 set -e -x
 
 if [ "$#" -ne 1 ]; then
@@ -7,18 +12,39 @@ if [ "$#" -ne 1 ]; then
   echo "Usage:"
   echo "   ./activate-org.sh <org name>"
   echo
-    exit 1
+  exit 1
+fi
+
+# Check to see if the person has at least version 7 of the cf CLI; if not, let
+# them know to upgrade and exit.
+min_cf_version=7
+cf_version=$(cf version | awk '{print $3}' | cut -c 1)
+
+if [ "$cf_version" -lt "$min_cf_version" ]; then
+  echo
+  echo "You must update your cf CLI to at least version 7."
+  echo "Please run: brew update && brew upgrade cf-cli@7"
+  echo
+  exit 1
 fi
 
 org_name=$1
 GUID=$(cf org "${org_name}" --guid)
 
-cf curl "/v2/organizations/${GUID}" -X PUT -d '{"status":"active"}'
+# Set the organization to not be suspended.
+cf curl "/v3/organizations/${GUID}" -X PATCH -d '{"suspended": false}'
 
 cf target -o "${org_name}"
-for space in $(cf spaces "${org_name}" | tail -n +4); do
+
+# Space names can contain spaces, so a for loop won't work as it'll break to
+# the next line upon the first whitespace character it reaches, not just a
+# newline character.  A while loop processes a whole line.
+cf spaces | tail -n +4 | while read -r space; do
   cf t -s "${space}" > /dev/null
-  for application in $(cf apps | tail -n +5); do
+
+  # The output of running `cf apps` includes more information than just the
+  # application name, which is the only thing we need.
+  for application in $(cf apps | tail -n +4 | awk '{ print $1 }'); do
     cf start "${application}"
   done
 done

--- a/suspend-org.sh
+++ b/suspend-org.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+# Activates an organization by setting its suspended status to true and starts
+# all stopped applications in all spaces of the organization.
+
+# Requires cf CLI version 7+ to work.
+
 set -e -x
 
 if [ "$#" -ne 1 ]; then
@@ -7,18 +12,41 @@ if [ "$#" -ne 1 ]; then
   echo "Usage:"
   echo "   ./suspend-org.sh <org name>"
   echo
-    exit 1
+
+  exit 1
+fi
+
+# Check to see if the person has at least version 7 of the cf CLI; if not, let
+# them know to upgrade and exit.
+min_cf_version=7
+cf_version=$(cf version | awk '{print $3}' | cut -c 1)
+
+if [ "$cf_version" -lt "$min_cf_version" ]; then
+  echo
+  echo "You must update your cf CLI to at least version 7."
+  echo "Please run: brew update && brew upgrade cf-cli@7"
+  echo
+
+  exit 1
 fi
 
 org_name=$1
 GUID=$(cf org "${org_name}" --guid)
 
-cf curl "/v2/organizations/${GUID}" -X PUT -d '{"status":"suspended"}'
+# Set the organization to suspended.
+cf curl "/v3/organizations/${GUID}" -X PATCH -d '{"suspended": true}'
 
 cf target -o "${org_name}"
-for space in $(cf spaces "${org_name}" | tail -n +4); do
+
+# Space names can contain spaces, so a for loop won't work as it'll break to
+# the next line upon the first whitespace character it reaches, not just a
+# newline character.  A while loop processes a whole line.
+cf spaces | tail -n +4 | while read -r space; do
   cf t -s "${space}" > /dev/null
-  for application in $(cf apps | tail -n +5); do
+
+  # The output of running `cf apps` includes more information than just the
+  # application name, which is the only thing we need.
+  for application in $(cf apps | tail -n +4 | awk '{ print $1 }'); do
     cf stop "${application}"
   done
 done


### PR DESCRIPTION
This changeset updates the active and suspend organization utility scripts so that they function correctly and utilize version 7 of the `cf` CLI as well as the V3 API.

## Changes proposed in this pull request
- Adds a check to make sure version 7 of the `cf` CLI is being used
- Switches to using the V3 API to manage the organizations and applications
- Provides some additional guidance and comments

## Security considerations
- None: this change only modifies (and fixes) the function of existing public utility scripts