### PR TITLE
Allow parsing of multiple ZAP reports

### DIFF
--- a/parse-owasp-zap-xml.py
+++ b/parse-owasp-zap-xml.py
@@ -4,27 +4,29 @@ import xml.etree.ElementTree as etree
 import sys
 
 if len(sys.argv) == 1:
-    print('please provide a path to an XML ZAP report')
+    print('please provide paths to one more XML ZAP reports')
     sys.exit(-1)
-filename = sys.argv[1]
 
-tree = etree.parse(filename)
-root = tree.getroot()
+filenames = sys.argv[1:]
+
 vulnids = {}
-for site in tree.findall('site'):
-    sitename = site.attrib['name']
-    if sitename.find('cloud.gov') != -1:
-        for alert in site.findall('.//alertitem'):
-            id = '{}, CWE id {}, WASC id {}, Risk {}, Plugin ID {}'.format(alert.find('name').text,
-                                                    alert.find('cweid').text,
-                                                    alert.findtext('wascid',"None"),
-                                                    alert.find('riskdesc').text,
-                                                    alert.find('pluginid').text)
-            sites = vulnids.get(id, [])
-            sites.append(sitename)
-            vulnids[id] = sites
-    else:
-        print(f'Info - Skipping non-cloud.gov site: {sitename}', file=sys.stderr)
+for filename in filenames:
+    tree = etree.parse(filename)
+    root = tree.getroot()
+    for site in tree.findall('site'):
+        sitename = site.attrib['name']
+        if sitename.find('cloud.gov') != -1:
+            for alert in site.findall('.//alertitem'):
+                id = '{}, CWE id {}, WASC id {}, Risk {}, Plugin ID {}'.format(alert.find('name').text,
+                                                        alert.find('cweid').text,
+                                                        alert.findtext('wascid',"None"),
+                                                        alert.find('riskdesc').text,
+                                                        alert.find('pluginid').text)
+                sites = vulnids.get(id, [])
+                sites.append(sitename)
+                vulnids[id] = sites
+        else:
+            print(f'Info - Skipping non-cloud.gov site: {sitename}', file=sys.stderr)
 
 for key in sorted(vulnids):
     print(key)


### PR DESCRIPTION
## Changes proposed in this pull request:
-
- Allow parsing of multiple ZAP reports
-

## Seems to work

internal only:
```sh
❯ parse-owasp-zap-xml.py 06/cloud-gov-internal-20210623.xml | grep -A10 Timestamp
Info - Skipping non-cloud.gov site: https://spocs.getpocket.com
Timestamp Disclosure - Unix, CWE id 200, WASC id 13, Risk Informational (Low), Plugin ID 10096
	https://admin.fr.cloud.gov
	https://alertmanager.fr.cloud.gov
	https://ci.fr.cloud.gov
	https://grafana.fr.cloud.gov
	https://logs-platform.fr.cloud.gov
	https://prometheus.fr.cloud.gov
```

external only
```sh
❯ parse-owasp-zap-xml.py 06/cloud-gov-external-20210623.xml | grep -A10 Timestamp
Info - Skipping non-cloud.gov site: https://spocs.getpocket.com
Info - Skipping non-cloud.gov site: https://ftp.mozilla.org
Timestamp Disclosure - Unix, CWE id 200, WASC id 13, Risk Informational (Low), Plugin ID 10096
	https://cloud.gov
	https://dashboard.fr.cloud.gov
	https://login.fr.cloud.gov
	https://logs.fr.cloud.gov
```

why not both?
```sh
❯ parse-owasp-zap-xml.py 06/cloud-gov-internal-20210623.xml 06/cloud-gov-external-20210623.xml | grep -A10 Timestamp
Info - Skipping non-cloud.gov site: https://spocs.getpocket.com
Info - Skipping non-cloud.gov site: https://spocs.getpocket.com
Info - Skipping non-cloud.gov site: https://ftp.mozilla.org
Timestamp Disclosure - Unix, CWE id 200, WASC id 13, Risk Informational (Low), Plugin ID 10096
	https://admin.fr.cloud.gov
	https://alertmanager.fr.cloud.gov
	https://ci.fr.cloud.gov
	https://cloud.gov
	https://dashboard.fr.cloud.gov
	https://grafana.fr.cloud.gov
	https://login.fr.cloud.gov
	https://logs-platform.fr.cloud.gov
	https://logs.fr.cloud.gov
	https://prometheus.fr.cloud.gov
```


## security considerations
Internal only file manipulation. No risk.
