### PR TITLE
add script for cdn

### DIFF
--- a/certbot/README.md
+++ b/certbot/README.md
@@ -2,7 +2,18 @@
 
 ## Usage
 
-This assumes you have set the environment variable CERTBOT_BUCKET_NAME to be the name
+Both scripts expect you have set the environment variable CERTBOT_BUCKET_NAME to be the name
 of the bucket we use for acme-challenge files, and that you have aws authentication
 available (e.g. you're running with `aws-vault exec ...`).
+
+examples:
+
+```bash session
+$ export CERTBOT_BUCKET_NAME=our-domains-bucket
+$ python3 alb_certs.py \
+    --alb-listener-arn <value from prometheus> \
+    --cert-name <value from prometheus>
+$ export CERTBOT_BUCKET_NAME=our-cdn-bucket
+$ python3 cdn_certs.py --cdn-id <value from prometheus>
+```
 

--- a/certbot/cdn_certs.py
+++ b/certbot/cdn_certs.py
@@ -1,0 +1,104 @@
+import argparse
+import copy
+import json
+import os
+import subprocess
+import sys
+
+import alb_certs
+
+script_dir = os.path.dirname(os.path.realpath(sys.argv[0]))
+
+
+def get_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--cdn-id", help="the id of the cloudfront distribution")
+    return parser.parse_args()
+
+
+def get_cdn_info(cdn_id):
+    command = [
+        "aws", "cloudfront",
+        "get-distribution-config",
+        "--id", cdn_id
+    ]
+    out = subprocess.run(command, capture_output=True, check=True, text=True)
+    return json.loads(out.stdout)
+
+
+def domains_from_cdn_info(cdn_info):
+    return cdn_info["DistributionConfig"]["Aliases"]["Items"]
+
+
+def cert_id_from_cdn_info(cdn_info):
+    return cdn_info["DistributionConfig"]["ViewerCertificate"]["IAMCertificateId"]
+
+
+def get_all_certs():
+    cert_metadata_list = []
+    all_certs_command = [
+        "aws", "iam",
+        "list-server-certificates"
+    ]
+    out = subprocess.run(all_certs_command, capture_output=True, check=True, text=True)
+    certs = json.loads(out.stdout)
+    cert_metadata_list.extend(certs["ServerCertificateMetadataList"])
+    while certs.get("NextToken", False):
+        # list here is a shortcut to copy the list
+        command = list(all_certs_command)
+        command.extend(["--starting-token", certs["NextToken"]])
+        out = subprocess.run(command, capture_output=True, check=True, text=True)
+        certs = json.loads(out.stdout)
+        cert_metadata_list.extend(certs["ServerCertificateMetadataList"])
+    return cert_metadata_list
+
+
+def cert_data_from_id(cert_id):
+    certs = get_all_certs()
+    for cert in certs:
+        if cert["ServerCertificateId"] == cert_id:
+            # dict here is shortcut to copy the cert
+            return dict(cert)
+
+
+def update_cdn_info(cdn_info, cert_data, cdn_id):
+    cert_id = cert_data["ServerCertificateId"]
+    cdn = copy.deepcopy(cdn_info)
+    config = cdn["DistributionConfig"]
+    etag = cdn["ETag"]
+    config["ViewerCertificate"]["IAMCertificateId"] = cert_data["ServerCertificateId"]
+    command = [
+        "aws", "cloudfront",
+        "update-distribution",
+        "--distribution-config", json.dumps(config),
+        "--if-match", etag, 
+        "--id", cdn_id
+    ]
+    subprocess.run(command, check=True)
+
+
+
+def main():
+    args = get_args()
+    if not os.getenv("CERTBOT_BUCKET_NAME"):
+        raise RuntimeError("CERTBOT_BUCKET_NAME must be set")
+    with alb_certs.cd(script_dir):
+        print("getting CDN information")
+        cdn_info = get_cdn_info(args.cdn_id)
+        domains = domains_from_cdn_info(cdn_info)
+        print("getting certificate information")
+        old_cert_id = cert_id_from_cdn_info(cdn_info)
+        cert_data = cert_data_from_id(old_cert_id)
+        print(cert_data)
+        guid = alb_certs.get_guid(cert_data["ServerCertificateName"])
+        print("getting certificate")
+        alb_certs.do_certbot(domains)
+        print("uploading certificate")
+        new_cert_info = alb_certs.upload_certs(domains[0], guid, "/cloudfront/cg-production/")
+        alb_certs.wait_print(10, "waiting for IAM to figure out cert")
+        update_cdn_info(cdn_info, new_cert_info, args.cdn_id)
+
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Changes proposed in this pull request:
- add script for cdn cert rotations
- fix wait_print newlines

Probably worth noting: this script does not attempt to delete the old IAM certificate. This is because we'd have to wait for Cloudfront to process the update, and I didn't want the script hanging for 30 minutes. 

We should just run through periodically and nuke expired IAM certs in commercial, anyway

## security considerations
None