### PR TITLE
add script for all cdn renewals

### DIFF
--- a/certbot/alb_certs.py
+++ b/certbot/alb_certs.py
@@ -48,6 +48,7 @@ def get_domains(guid):
 
     description = service_data["last_operation"]["description"]
     domains = description.split(';')[1].split(' ')[2:]
+    domains = [domain.replace(",","") for domain in domains]
     print(f"domains: {domains}")
  
     return domains
@@ -71,7 +72,7 @@ def do_certbot(domains):
     for domain in domains:
         command.extend(["-d", domain])
 
-    out = subprocess.run(command, capture_output=True, check=True)
+    out = subprocess.run(command, check=True)
 
 
 def upload_certs(domain, guid, path):
@@ -98,8 +99,7 @@ def upload_certs(domain, guid, path):
         "--path", path
     ]
     with cd(f"config/live/{domain}"):
-        out = subprocess.run(upload_command, capture_output=True, text=True,)# check=True)
-        print(out.stderr)
+        out = subprocess.run(upload_command, capture_output=True, text=True, check=True)
     data = json.loads(out.stdout)
     return data["ServerCertificateMetadata"]
 

--- a/certbot/cleanup.sh
+++ b/certbot/cleanup.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-rm $CERTBOT_TOKEN
+rm -- "$CERTBOT_TOKEN"

--- a/certbot/renew_all_cdns.sh
+++ b/certbot/renew_all_cdns.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+## Calculate the days to expiration from now
+function days_to_cert_expiration {
+  local cloudfront=$1;
+  local alias=$2;
+  local date_today=$(gdate +%s);
+
+  ## Get expirationdate and convert to epoch
+  expirationdate=$(gdate -d "$(: | openssl s_client -connect $cloudfront:443 -servername $alias 2>/dev/null \
+    | openssl x509 -text \
+    | grep 'Not After' \
+    | awk '{print $4,$5,$7}')" '+%s');
+
+  ## Check the seconds to expiration from now
+  seconds_to_go=$(expr $expirationdate - $date_today)\
+
+  if ! [[ $seconds_to_go -gt 0 ]]; then
+    ## Return integer less than or equal to 0
+    seconds_past=$(expr $date_today - $expirationdate)
+    negative_days=$(($seconds_past / 86400))
+    echo $((0 - $negative_days))
+  else
+     ## Return integer greater than or equal to 0
+    echo $(($seconds_to_go / 86400))
+  fi
+}
+
+## Select and get Cloudfront instances returning ARN, & Aliases
+alias_count=0
+cdn_count=0
+cdns_selector='.DistributionList.Items[] | select(.Aliases.Items != null) | {id:.Id,arn:.ARN,aliases:.Aliases.Items,domain:.DomainName}'
+cdns=$(aws cloudfront list-distributions | jq -c "${cdns_selector}")
+cdn_list=($cdns)
+
+## Loop through list of CDN instances
+cdn_certificate_expirations=""
+for cdn in "${cdn_list[@]}"; do
+  cdn_count=$((cdn_count + 1))
+  aliases=($(echo $cdn | jq -r ".aliases[]"))
+  arn=($(echo $cdn | jq -r ".arn"))
+  domain=($(echo $cdn | jq -r ".domain"))
+  id=($(echo $cdn | jq -r ".id"))
+
+  for alias in "${aliases[@]}"; do
+    alias_count=$((alias_count + 1))
+    days_to_expire=$(days_to_cert_expiration $domain $alias)
+    if [[ $days_to_expire -lt 25 ]]; then
+      echo "${id} expires in ${days_to_expire}"
+      cdn_certificate_expirations="${cdn_certificate_expirations} ${id}"
+    fi
+  done
+done
+cdn_certificate_expirations=$(echo ${cdn_certificate_expirations} | sort | uniq)
+
+python3 cdn_certs.py --cdn-ids ${cdn_certificate_expirations}

--- a/delete-expired-server-certificates.py
+++ b/delete-expired-server-certificates.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+import argparse
+import subprocess
+import datetime
+import json
+
+def get_certificates():
+    command = ["aws", "iam", 
+    "list-server-certificates"
+    ]
+    out = subprocess.run(command, check=True, capture_output=True)
+    cert_obj = json.loads(out.stdout)
+    return cert_obj["ServerCertificateMetadataList"]
+
+
+def delete_certificate(name, dry_run):
+    command = ["aws", "iam", 
+    "delete-server-certificate",
+    "--server-certificate-name", name]
+    print(command)
+    if not dry_run:
+        subprocess.run(command)
+
+
+def is_too_old(cert):
+    now = datetime.datetime.now()
+    expiration = cert["Expiration"]
+    expiration = datetime.datetime.strptime(expiration, "%Y-%m-%dT%H:%M:%SZ")
+    return expiration < now
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    certs = get_certificates()
+    expired_certs = [cert for cert in certs if is_too_old(cert)]
+    for cert in expired_certs:
+        delete_certificate(cert["ServerCertificateName"], args.dry_run)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add a script to attempt to renew all expiring cdn certs
- Fix cleanup script for cases where the filename begins with `-`
- Fix multiple domain parsing for ALBs
- Add script to clean up expired certificates from iam

## security considerations
Automating means we're less likely to make mistakes from typos, etc, but also amplifies our ability to make bigger errors