### PR TITLE
Add new spaces for egress when creating a new org

### DIFF
--- a/cf-create-org.sh
+++ b/cf-create-org.sh
@@ -94,7 +94,7 @@ cf set-org-role "$MANAGER" "$ORG_NAME" OrgManager
 declare -a spaces=("dev" "staging" "prod")
 for SPACE in "${spaces[@]}"
 do
-  declare -a spacetypes=("public" "internal" "private")
+  declare -a spacetypes=("public-egress" "restricted-egress" "closed-egress")
   for SPACETYPE in "${spacetypes[@]}"
   do
     cf create-space -o "$ORG_NAME" "$SPACE-$SPACETYPE"


### PR DESCRIPTION
To support newly created orgs with our additional egress controls, all new orgs will have nine spaces based on three envs and each env having three egress types.

_Naming suggestions for the egress types welcome!_

## Changes proposed in this pull request:
- Add "public", "internal", and "private" to new org spaces to allow for different egress options
  - `<env>-public`: Apps can send requests to the public internet and our internal service like RDS
  - `<env>-internal`: Apps can only send requests to the internal services: RDS, ES, Redis
  - `<env>-private`: Apps are locked down
  
## security considerations
Will improve egress control for tenant apps
