### PR TITLE
Improve active sandbox and space count script

### DIFF
--- a/audit/get-active-sandbox-and-space-count.sh
+++ b/audit/get-active-sandbox-and-space-count.sh
@@ -2,44 +2,100 @@
 
 set -e
 
-# Counts the number of current active sandboxes in the platform.
+# Provides counts for the following:
+# - The total number of sandboxes spaces currently in the platform
+# - The number of current active sandboxes in the platform
+# - Optionally provides number of sandboxe spaces created with provided dates or
+#   a date range
 
 # An active sandbox is defined as any user's sandbox space with 1 or more
-# running apps in it.
+# running apps in it.  Sandboxes are cleared out every 90 days from the time of
+# first activity, so we can only ever count what is currently running.  That
+# said, we can determine these counts by using the cf CLI and CAPI to retrieve
+# all sandbox orgs, then filter a list of all apps with those corresponding org
+# GUIDs.
 
-# We can determine this by using the cf CLI and CAPI to retrieve all sandbox
-# orgs, then filter a list of all apps with those corresponding org GUIDs.
+# Sandbox spaces are defined as any space within a sandbox organization, e.g.,
+# all spaces under the sandbox-gsa org.
 
-if [[ $1 == "--help" ]]; then
-  echo " "
-  echo "Counts the number of current active sandboxes in the platform."
-  echo " "
-	echo "Usage: get-active-sandbox-and-space-count [START_DATE] [END_DATE]"
-  echo " "
-  echo -e "  START_DATE: \t A date to limit finding active sandboxes at or after the provided date in YYYY-MM-DD format."
-  echo -e "  END_DATE: \t A date to limit finding active sandboxes at or before the provided date in YYYY-MM-DD format."
-  echo " "
-	exit 0
-fi
+# Help information for this script.
+script_help() {
+    cat << EOF
 
-start_date=$1
-end_date=$2
+Counts the number of current active sandboxes and total sandboxes spaces in the platform.
+
+Usage: ${0##*/} [--start-date START_DATE] [--end-date END_DATE]
+
+    -?, -h, --help  Display this help and exit
+    --start-date    Limit finding sandbox spaces at or after the provided date in YYYY-MM-DD format
+    --end-date      Limit finding sandboxes spaces at or before the provided date in YYYY-MM-DD format
+EOF
+}
+
+start_date=""
+end_date=""
 extra_params=""
+
+# Loop through script options.
+while :; do
+    case $1 in
+        # Script help options
+        -\?|-h|--help)
+            script_help
+            exit
+            ;;
+        # Start date option
+        --start-date)
+            if [ "$2" ]; then
+                if [[ "$2" =~ ^[0-9]{4}\-[0-9]{2}\-[0-9]{2}$ ]]; then
+                    start_date=$2
+                    shift
+                else
+                    echo 'ERROR: "--start-date" must be in YYYY-MM-DD format.'
+                    exit
+                fi
+            else
+                echo 'ERROR: "--start-date" requires a non-empty option argument.'
+                exit
+            fi
+            ;;
+        # End date option
+        --end-date)
+            if [ "$2" ]; then
+                if [[ "$2" =~ ^[0-9]{4}\-[0-9]{2}\-[0-9]{2}$ ]]; then
+                    end_date=$2
+                    shift
+                else
+                    echo 'ERROR: "--end-date" must be in YYYY-MM-DD format.'
+                    exit
+                fi
+            else
+                echo 'ERROR: "--end-date" requires a non-empty option argument.'
+                exit
+            fi
+            ;;
+        # Default case; ignore anything else, no more options to parse.
+        *)
+            break
+    esac
+
+    shift
+done
 
 echo "Getting total counts of active sandboxes and sandbox spaces..."
 
-# If a start date was given, filter for sandboxes created at the start date and
-# after, starting at the very beginning of the day.
+# If a start date was given, filter for sandbox spaces created at the start
+# date and after, starting at the very beginning of the day.
 if [ $start_date ]; then
     extra_params="${extra_params}&created_ats[gte]=${start_date}T00:00:00Z"
-    echo "    [Limiting search to sandboxes active starting on ${start_date} (00:00:00)]"
+    echo "    [Perfoming extra search for sandbox spaces only created on ${start_date} (00:00:00) and after]"
 fi
 
-# If an end date was given, filter for sandboxes created before the very end of
-# the day given and before.
+# If an end date was given, filter for sandbox spaces created before the very
+# end of the day given and before.
 if [ $end_date ]; then
     extra_params="${extra_params}&created_ats[lte]=${end_date}T23:59:59Z"
-    echo "    [Limiting search to sandboxes active no later than ${end_date} (23:59:59)]"
+    echo "    [Perfoming extra search for sandbox spaces only created on ${end_date} (23:59:59) and before]"
 fi
 
 echo
@@ -57,7 +113,8 @@ sandbox_org_guids=$(cf curl "/v3/organizations?names=${sandbox_org_names}&per_pa
 echo "...Retrieving total number of spaces for all sandbox orgs..."
 total_sandbox_spaces=$(cf curl "/v3/spaces?organization_guids=${sandbox_org_guids}&per_page=5000" | jq -r '.pagination.total_results')
 
-# If we've set any dates, also check for spaces created during that time period.
+# If we're given any dates, also check for spaces created during the specified
+# time frame(s).
 if [ $extra_params ]; then
     echo "...Retrieving number of spaces created in all sandbox orgs during dates given..."
     total_sandboxe_spaces_created=$(cf curl "/v3/spaces?organization_guids=${sandbox_org_guids}&per_page=5000${extra_params}" | jq -r '.pagination.total_results')
@@ -65,14 +122,16 @@ fi
 
 # Retrieve the count of all running apps across all sandbox orgs, regardless of
 # the actual space they're running in.
-echo "...Retrieving total number of active sandboxes for all sandbox orgs..."
-total_active_sandboxes=$(cf curl "/v3/apps?organization_guids=${sandbox_org_guids}&per_page=5000${extra_params}" | jq -r '.pagination.total_results')
+echo "...Retrieving total number of current active sandboxes for all sandbox orgs..."
+total_active_sandboxes=$(cf curl "/v3/apps?organization_guids=${sandbox_org_guids}&per_page=5000" | jq -r '.pagination.total_results')
 
 # Print the final results.
 echo
 echo "Total number of sandbox spaces: ${total_sandbox_spaces}"
-echo "Total number of active sandboxes: ${total_active_sandboxes}"
+echo "Total number of current active sandboxes: ${total_active_sandboxes}"
 
+# If any dates were given, provide the number of sandbox spaces created during
+# the specific time frame(s).
 if [ $extra_params ]; then
-    echo "Total number of sandbox spaces created during given dates: ${total_sandboxe_spaces_created}"
+    echo "Total number of sandbox spaces created during the given dates: ${total_sandboxe_spaces_created}"
 fi

--- a/audit/get-active-sandbox-and-space-count.sh
+++ b/audit/get-active-sandbox-and-space-count.sh
@@ -3,10 +3,10 @@
 set -e
 
 # Provides counts for the following:
-# - The total number of sandboxes spaces currently in the platform
+# - The total number of sandbox spaces currently in the platform
 # - The number of current active sandboxes in the platform
-# - Optionally provides number of sandboxe spaces created with provided dates or
-#   a date range
+# - Optionally provides the number of sandbox spaces created within a certain
+#   timeframe given any provided dates or date range
 
 # An active sandbox is defined as any user's sandbox space with 1 or more
 # running apps in it.  Sandboxes are cleared out every 90 days from the time of
@@ -22,29 +22,48 @@ set -e
 script_help() {
     cat << EOF
 
-Counts the number of current active sandboxes and total sandboxes spaces in the platform.
+A script that provides counts for the following:
+
+- The total number of sandbox spaces currently in the platform
+
+- The number of current active sandboxes in the platform
+
+- Optionally provides the number of sandbox spaces created within a certain
+  timeframe given any provided dates or date range
+
 
 Usage: ${0##*/} [--start-date START_DATE] [--end-date END_DATE]
 
-    -?, -h, --help  Display this help and exit
-    --start-date    Limit finding sandbox spaces at or after the provided date in YYYY-MM-DD format
-    --end-date      Limit finding sandboxes spaces at or before the provided date in YYYY-MM-DD format
+    -?, -h, --help  Display this help message and exit
+
+    --start-date    Retrieve an additional count of sandbox spaces that were
+                    created at or after the provided start date; must be in
+                    YYYY-MM-DD format
+
+    --end-date      Retrieve an additional count of sandbox spaces that were
+                    created at or before the provided end date; must be in
+                    YYYY-MM-DD format
+
+Including both the --start-date and --end-date arguments will restrict the
+additional sandbox space count to the date range provided with both dates.
 EOF
 }
 
+# Initialize sript variables.
 start_date=""
 end_date=""
 extra_params=""
 
-# Loop through script options.
+# Loop through script options to parse any provided options and retrieve their
+# arguments.
 while :; do
     case $1 in
-        # Script help options
+        # Display script help.
         -\?|-h|--help)
             script_help
             exit
             ;;
-        # Start date option
+        # Parse the start date option.
         --start-date)
             if [ "$2" ]; then
                 if [[ "$2" =~ ^[0-9]{4}\-[0-9]{2}\-[0-9]{2}$ ]]; then
@@ -59,7 +78,7 @@ while :; do
                 exit
             fi
             ;;
-        # End date option
+        # Parse the end date option.
         --end-date)
             if [ "$2" ]; then
                 if [[ "$2" =~ ^[0-9]{4}\-[0-9]{2}\-[0-9]{2}$ ]]; then
@@ -74,7 +93,8 @@ while :; do
                 exit
             fi
             ;;
-        # Default case; ignore anything else, no more options to parse.
+        # Default case; ignore anything else passed in, there are no more
+        # options to parse.
         *)
             break
     esac
@@ -114,7 +134,7 @@ echo "...Retrieving total number of spaces for all sandbox orgs..."
 total_sandbox_spaces=$(cf curl "/v3/spaces?organization_guids=${sandbox_org_guids}&per_page=5000" | jq -r '.pagination.total_results')
 
 # If we're given any dates, also check for spaces created during the specified
-# time frame(s).
+# timeframe(s).
 if [ $extra_params ]; then
     echo "...Retrieving number of spaces created in all sandbox orgs during dates given..."
     total_sandboxe_spaces_created=$(cf curl "/v3/spaces?organization_guids=${sandbox_org_guids}&per_page=5000${extra_params}" | jq -r '.pagination.total_results')
@@ -131,7 +151,7 @@ echo "Total number of sandbox spaces: ${total_sandbox_spaces}"
 echo "Total number of current active sandboxes: ${total_active_sandboxes}"
 
 # If any dates were given, provide the number of sandbox spaces created during
-# the specific time frame(s).
+# the specific timeframe(s).
 if [ $extra_params ]; then
     echo "Total number of sandbox spaces created during the given dates: ${total_sandboxe_spaces_created}"
 fi

--- a/audit/get-active-sandbox-and-space-count.sh
+++ b/audit/get-active-sandbox-and-space-count.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Counts the number of current active sandboxes in the platform.
 
 # An active sandbox is defined as any user's sandbox space with 1 or more
@@ -8,7 +10,38 @@
 # We can determine this by using the cf CLI and CAPI to retrieve all sandbox
 # orgs, then filter a list of all apps with those corresponding org GUIDs.
 
+if [[ $1 == "--help" ]]; then
+  echo " "
+  echo "Counts the number of current active sandboxes in the platform."
+  echo " "
+	echo "Usage: get-active-sandbox-and-space-count [START_DATE] [END_DATE]"
+  echo " "
+  echo -e "  START_DATE: \t A date to limit finding active sandboxes at or after the provided date in YYYY-MM-DD format."
+  echo -e "  END_DATE: \t A date to limit finding active sandboxes at or before the provided date in YYYY-MM-DD format."
+  echo " "
+	exit 0
+fi
+
+start_date=$1
+end_date=$2
+extra_params=""
+
 echo "Getting total counts of active sandboxes and sandbox spaces..."
+
+# If a start date was given, filter for sandboxes created at the start date and
+# after, starting at the very beginning of the day.
+if [ $start_date ]; then
+    extra_params="${extra_params}&created_ats[gte]=${start_date}T00:00:00Z"
+    echo "    [Limiting search to sandboxes active starting on ${start_date} (00:00:00)]"
+fi
+
+# If an end date was given, filter for sandboxes created before the very end of
+# the day given and before.
+if [ $end_date ]; then
+    extra_params="${extra_params}&created_ats[lte]=${end_date}T23:59:59Z"
+    echo "    [Limiting search to sandboxes active no later than ${end_date} (23:59:59)]"
+fi
+
 echo
 
 # Get all of the sandbox orgs in a format to be used with a cf curl call.
@@ -24,12 +57,22 @@ sandbox_org_guids=$(cf curl "/v3/organizations?names=${sandbox_org_names}&per_pa
 echo "...Retrieving total number of spaces for all sandbox orgs..."
 total_sandbox_spaces=$(cf curl "/v3/spaces?organization_guids=${sandbox_org_guids}&per_page=5000" | jq -r '.pagination.total_results')
 
+# If we've set any dates, also check for spaces created during that time period.
+if [ $extra_params ]; then
+    echo "...Retrieving number of spaces created in all sandbox orgs during dates given..."
+    total_sandboxe_spaces_created=$(cf curl "/v3/spaces?organization_guids=${sandbox_org_guids}&per_page=5000${extra_params}" | jq -r '.pagination.total_results')
+fi
+
 # Retrieve the count of all running apps across all sandbox orgs, regardless of
 # the actual space they're running in.
 echo "...Retrieving total number of active sandboxes for all sandbox orgs..."
-total_active_sandboxes=$(cf curl "/v3/apps?organization_guids=${sandbox_org_guids}&per_page=5000" | jq -r '.pagination.total_results')
+total_active_sandboxes=$(cf curl "/v3/apps?organization_guids=${sandbox_org_guids}&per_page=5000${extra_params}" | jq -r '.pagination.total_results')
 
 # Print the final results.
 echo
-echo "Total number of sandbox spaces: $total_sandbox_spaces"
-echo "Total number of active sandboxes: $total_active_sandboxes"
+echo "Total number of sandbox spaces: ${total_sandbox_spaces}"
+echo "Total number of active sandboxes: ${total_active_sandboxes}"
+
+if [ $extra_params ]; then
+    echo "Total number of sandbox spaces created during given dates: ${total_sandboxe_spaces_created}"
+fi


### PR DESCRIPTION
This changeset adds a few improvements to the active sandbox and space count script by allowing an operator to specify start and end dates to filter by.  If a start date (and an end date) are given, the results are constrained to those dates in an inclusive fashion: starting at 00:00:00 on the start date and ending at 23:59:59 on the end date (if provided).

Including the dates will also provide a new line of output, how many sandbox spaces were created during that time.

## Changes proposed in this pull request:
- Add support for accepting `--start-date` and `--end-date` arguments
- Add extra output when running the script with dates
- Add some help text when supplying a `-? / -h / --help` argument

## Security considerations:
- None; utilizes CAPI calls that all users of the system have access to