### PR TITLE
Add support for an origin flag

### DIFF
--- a/cf-create-org.sh
+++ b/cf-create-org.sh
@@ -14,8 +14,8 @@ SYSTEM_NAME=$3
 POP_START=$4
 POP_END=$5
 MANAGER=$6
+MEMORY=$7
 
-MEMORY="${7:-4G}"
 MANAGER_ORIGIN="${8:-}"
 
 # Checks to see if an origin was set for the manager; if so, this will be used


### PR DESCRIPTION
This changeset adds support for accepting an origin flag to use when setting roles for a new organization. By default the flag is not used, but if the argument is present it will be passed in as a flag for the `set-org-role` and `set-space-role` commands.

## Changes proposed in this pull request:
- Add support for a `MANAGER_ORIGIN` argument
- Add a check to pass in the `--origin` flag for `cf set-org-role` and `cf set-space-role`

## Security considerations:
- None; the script can only be run by a platform operator, and adding the origin flag just lets CF know how to set the correct user