### PR TITLE
Fix create-org script

### DIFF
--- a/cf-create-org.sh
+++ b/cf-create-org.sh
@@ -15,8 +15,9 @@ POP_START=$4
 POP_END=$5
 MANAGER=$6
 MEMORY=$7
+MANAGER_ORIGIN=$8
 
-MANAGER_ORIGIN="${8:-}"
+ORIGIN_FLAG=""
 
 # Checks to see if an origin was set for the manager; if so, this will be used
 # for setting the roles later on.


### PR DESCRIPTION
This changeset fixes an issue with the create-org script and the recently added `--origin` flag

## Changes proposed in this pull request:
- Fix handling of script arguments default values for the `--origin` flag

## security considerations:
- None