### PR TITLE
Generating lightweight SBOM from Bosh

### DIFF
--- a/bosh-unpack.py
+++ b/bosh-unpack.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+import sys
+import urllib.request
+import yaml
+
+releases = {
+        'aide' :            { 'repo' : '/cloud-gov/aide-boshrelease/master',
+                                'vendor' : False },
+        'awslogs-bionic' : { 'repo' : '/cloud-gov/cg-awslogs-boshrelease/master',
+                                'vendor' : False },
+        'clamav':            { 'repo' : '/cloud-gov/cg-clamav-boshrelease/master',
+                                'vendor' : False },
+        'fisma':            { 'repo' : '/cloud-gov/cg-harden-boshrelease/master', },
+        'nessus-agent':      { 'repo' : '/cloud-gov/cg-nessus-agent-boshrelease/master', },
+        'node-exporter':      { 'repo' : '/bosh-prometheus/node-exporter-boshrelease/master' },
+        'secureproxy'  :    { 'repo' : '/cloud-gov/cg-secureproxy-boshrelease/master', },
+        'shibboleth'  :    { 'repo' : '/cloud-gov/shibboleth-boshrelease/master', },
+        'snort':            { 'repo' : '/cloud-gov/cg-snort-boshrelease/master', },
+        'syslog'       :     { 'repo' : '/cloudfoundry/syslog-release/main' }
+}
+
+blobs="/config/blobs.yml"
+
+for line in sys.stdin.readlines():
+    print( line.strip() )
+    rel=line.split('/')[0] or exit()
+    url = "https://raw.githubusercontent.com" + releases[rel]['repo']+blobs
+    #print( url )
+    yaml_data = urllib.request.urlopen(url).read()
+    data = yaml.safe_load(yaml_data)
+    if data:
+        print(list(data.keys()))

--- a/bosh-unpack.py
+++ b/bosh-unpack.py
@@ -23,11 +23,13 @@ releases = {
 blobs="/config/blobs.yml"
 
 for line in sys.stdin.readlines():
-    print( line.strip() )
+    print( line.strip(),":" )
     rel=line.split('/')[0] or exit()
     url = "https://raw.githubusercontent.com" + releases[rel]['repo']+blobs
     #print( url )
     yaml_data = urllib.request.urlopen(url).read()
     data = yaml.safe_load(yaml_data)
     if data:
-        print(list(data.keys()))
+        print("\t", list(data.keys()))
+    else:
+        print("\t[]")


### PR DESCRIPTION
## Changes proposed in this pull request:
-
-

Example:

```
printf $(bosh deployment -d shibboleth-staging --json | jq '.Tables[0].Rows[0].release_s')"\n" | sed -e 's/\"//g' | ./bosh-unpack.py
```

## security considerations
[Note the any security considerations here, or make note of why there are none]
