### PR TITLE
add groups with permissions to manage routing for CF admins

### DIFF
--- a/make-cf-admin.sh
+++ b/make-cf-admin.sh
@@ -9,7 +9,7 @@ if [ "$#" -lt 1 ]; then
   echo
   echo "  Options:"
   echo "     -r    :    Remove the user instead of add"
-  echo 
+  echo
   echo "  Be sure to run ./cg-scripts/uaa/login.sh prior to executing this script"
   echo
   exit 1;
@@ -33,15 +33,15 @@ if ! hash uaac 2>/dev/null; then
   gem install cf-uaac
 fi
 
-declare -a admin_groups=("cloud_controller.admin" "uaa.admin" "scim.read" "scim.write" "admin_ui.admin" "network.admin")
+declare -a admin_groups=("cloud_controller.admin" "uaa.admin" "scim.read" "scim.write" "admin_ui.admin" "network.admin" "routing.router_groups.read" "routing.router_groups.write")
 if $REMOVE; then
-  for group in ${admin_groups[@]}
+  for group in "${admin_groups[@]}"
   do
     echo -n "Removing user from group ${group}... "
     uaac member delete "${group}" "${USER}" || true
   done
 else
-  for group in ${admin_groups[@]}
+  for group in "${admin_groups[@]}"
   do
     echo -n "Adding user to group ${group}... "
     uaac member add "${group}" "${USER}" || true


### PR DESCRIPTION
## Changes proposed in this pull request:

- add groups with permissions to manage routing for CF admins

## security considerations

Gives CF admins permission to manage routing for CF, but that seems desirable?
