### PR TITLE
fix newlines in output from cf-user-get-roles.sh script

### DIFF
--- a/cf-get-user-roles.sh
+++ b/cf-get-user-roles.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Grabs all cf org and space roles for a user
 
@@ -41,4 +41,4 @@ headers=$(echo "role", "org_uuid", "space_uuid")
 formatted_list=$(echo $role_list | jq -r '.resources[] | [.type, .relationships.organization.data.guid // "null", .relationships.space.data.guid // "null"] | @csv')
 
 #output a nice table
-echo "$headers\n$formatted_list" | column -t -s,
+echo -e "$headers\\n$formatted_list" | column -t -s,


### PR DESCRIPTION
## Changes proposed in this pull request:

- fix cf-user-get-roles.sh script so that a newline is properly inserted between the table headers and table contents

## security considerations

None
