### PR TITLE
fix create org script

### DIFF
--- a/cf-create-org.sh
+++ b/cf-create-org.sh
@@ -93,7 +93,7 @@ ADMIN=$(cf target | grep -i user | awk '{print $2}')
 cf create-org "$ORG_NAME" -q "$HASHED_QUOTA_NAME"
 # creator added by default, which is usually not desirable
 cf unset-org-role "$ADMIN" "$ORG_NAME" OrgManager
-cf set-org-role "$MANAGER" "$ORG_NAME" OrgManager "$ORIGIN_FLAG"
+cf set-org-role "$MANAGER" "$ORG_NAME" OrgManager ${ORIGIN_FLAG:+"$ORIGIN_FLAG"}
 
 # Step 4: Create the spaces
 declare -a spaces=("dev" "staging" "prod")
@@ -105,11 +105,11 @@ do
   cf unset-space-role "$ADMIN" "$ORG_NAME" "$SPACE" SpaceManager
   cf unset-space-role "$ADMIN" "$ORG_NAME" "$SPACE" SpaceDeveloper
 
-  cf set-space-role "$MANAGER" "$ORG_NAME" "$SPACE" SpaceDeveloper "$ORIGIN_FLAG"
+  cf set-space-role "$MANAGER" "$ORG_NAME" "$SPACE" SpaceDeveloper ${ORIGIN_FLAG:+"$ORIGIN_FLAG"}
 done
 
 
-# deleting admin user from newly created org. 
+# deleting admin user from newly created org.
 # https://github.com/cloudfoundry/cli/issues/781
 USER_GUID=$(cf curl "/v3/users?usernames=${ADMIN}"| jq -r '.resources[] | .guid')
 ORG_GUID=$(cf org "${ORG_NAME}" --guid)


### PR DESCRIPTION
## Changes proposed in this pull request:

Initially running this script I got some errors because `$ORIGIN_FLAG` was equal to `""`, so extra `''` were showing up in the `cf` commands and causing them to fail. The BASH substitution syntax I've added should fix the errors.

## security considerations

None, just fixing the commands in this script
