### PR TITLE
Format structured secrets as JSON

### DIFF
--- a/credhub-format.sh
+++ b/credhub-format.sh
@@ -52,7 +52,7 @@ cat $source | \
     credentials: [ .[] |
       {
         name: ("/concourse/main/"+$pipelinename+"/"+.key),
-        type: "value",
+        type: (if .value | type == "object" then "json" else "value" end),
         value: .value
       }
     ]


### PR DESCRIPTION
CredHub supports importing secrets as json, and when imported in this format, existing interpolations of the form ((variable.key)) will continue working.

## security considerations
None.