### PR TITLE
Update Pages production domain services to point CDN origin to the pages proxy 

### DIFF
--- a/pages/update-cdn-origins.sh
+++ b/pages/update-cdn-origins.sh
@@ -1,0 +1,103 @@
+#! /bin/bash
+
+set -e
+
+display_usage() {
+  echo -e "\nUsage: $0 input.csv [max-rows] [offset]\n"
+  echo -e "  max-rows: process at most this number of input rows (default: unlimited)\n"
+  echo -e "  offset:   skip an initial set of input rows (default: 0)\n"
+}
+
+if [  $# -le 0 ]
+then
+  display_usage
+  exit 1
+fi
+
+if [[ ( $@ == "--help") ||  $@ == "-h" ]]
+then
+  display_usage
+  exit 0
+fi
+
+# Decision made to run this from a different environment. Hence:
+# TODO: Eliminate input file and instead query DB from within the script
+# TODO: Eliminate SQL output and instead update DB from within primary loop
+
+# Expected input file is a comma-seperated-value export of the serviceName and
+# origin columns for provisioned domains in the domains table in the core DB.
+#
+# The expected format can be produced from the psql command line as follows:
+#
+# \copy (select "serviceName",origin from domain where state='provisioned') to '/output/path/for/domains.csv' CSV HEADER;
+domains_file=$1
+
+max_rows=${2:--1}
+
+offset=${3:-0}
+
+if [[ ! -r $domains_file ]]
+then
+  echo "Input file $domains_file does not exist or is not readable"
+  exit 1
+fi
+
+# QUESTION: Should this type of script test for CF session and/or verify targeted org/space?
+
+# QUESTION: Does wait_for_service_instance() require the following?
+#
+# CF Auth
+# cf api "${CF_API_URL}"
+# (set +x; cf auth "${CF_USERNAME}" "${CF_PASSWORD}")
+
+# Waiting for service instance to finish being processed.
+wait_for_service_instance() {
+  local service_name=$1
+  local guid=$(cf service --guid $service_name)
+  local status=$(cf curl /v2/service_instances/${guid} | jq -r '.entity.last_operation.state')
+
+  while [ "$status" == "in progress" ]; do
+    sleep 60
+    status=$(cf curl /v2/service_instances/${guid} | jq -r '.entity.last_operation.state')
+  done
+}
+
+rows_processed=0
+SQL=""
+while IFS="," read -r service_instance current_origin
+do
+  if [[ $offset -gt 0 ]]
+  then
+    ((offset--))
+    continue
+  fi
+
+  ((rows_processed++))
+
+  if [[ ($max_rows -gt 0) && ($rows_processed -gt $max_rows)]]
+  then
+    break
+  fi
+
+  if [[ $current_origin =~ (.*)\.app\.cloud\.gov$ ]]
+  then
+    bucket=${BASH_REMATCH[1]}
+    new_origin="$bucket.sites.pages.cloud.gov"
+
+    # For the moment, outputting instead of executing this command...
+    echo "cf update-service $service_instance -c '{\"origin\": \"$new_origin\"}'"
+
+    # ... and since we're not executing that we're not yet going to
+    # wait_for_service_instance $SERVICE_INSTANCE"
+
+    # Here's the SQL we'll need to run to update the database once the origin is updated
+    SQL+="update domain set origin='$new_origin' where \"serviceName\"='$service_instance';"$'\n'
+  fi
+done < $domains_file
+
+# TODO: Ensure that this happens even if an error occurs in the loop above
+if [[ ${#SQL} -gt 0 ]]
+then
+  echo -e "\nThe following SQL will need to be executed against the database:\n"
+  echo "$SQL"
+fi

--- a/pages/update-cdn-origins.sh
+++ b/pages/update-cdn-origins.sh
@@ -4,9 +4,8 @@ set -e
 
 # Process parameters
 display_usage() {
-  echo -e "\nUsage: $0 [max-rows] [offset]\n"
-  echo -e "  max-rows: process at most this number of input rows (default: unlimited)\n"
-  echo -e "  offset:   skip an initial set of input rows (default: 0)\n"
+  echo -e "\nUsage: $0 [max-domains]\n"
+  echo -e "  max-domains: process at most this number of input rows (default: unlimited)\n"
 }
 
 if [[ ( $@ == "--help") ||  $@ == "-h" ]]
@@ -15,8 +14,7 @@ then
   exit 0
 fi
 
-max_rows=${1:--1}
-offset=${2:-0}
+max_domains=${1:--1}
 
 # Check for required environment variables
 [ -z "${CF_API_URI}"  ] && echo -e "\n Required CF_API_URI environment variable is not set\n";  exit 1
@@ -49,15 +47,9 @@ query="select \"serviceName\",origin from domain where state='provisioned' and o
 domains=`psql ${DB_URI} --csv -t -c "$query"`
 while IFS="," read -r service_instance current_origin
 do
-  if [[ $offset -gt 0 ]]
-  then
-    ((offset--))
-    continue
-  fi
-
   ((rows_processed++))
 
-  if [[ ($max_rows -gt 0) && ($rows_processed -gt $max_rows)]]
+  if [[ ($max_domains -gt 0) && ($rows_processed -gt $max_domains)]]
   then
     break
   fi

--- a/pages/update-cdn-origins.sh
+++ b/pages/update-cdn-origins.sh
@@ -25,7 +25,7 @@ max_domains=${1:--1}
 [ -z "${DB_URI}"      ] && echo -e "\n Required DB_URI environment variable is not set\n"; exit 1
 
 # Authenticate and set Cloud Foundry target
-cf api "${CF_API_URL}"
+cf api "${CF_API_URI}"
 (set +x; cf auth "${CF_USERNAME}" "${CF_PASSWORD}")
 cf target -o "${CF_ORG}" -s "${CF_SPACE}"
 

--- a/pages/update-cdn-origins.sh
+++ b/pages/update-cdn-origins.sh
@@ -62,7 +62,7 @@ do
 
     # Update the service
     echo "Updating $service_instance origin"
-    cf update-service $service_instance -c '{\"origin\": \"$new_origin\"}'
+    cf update-service $service_instance -c '{"origin": "'$new_origin'"}'
 
     # Wait for update-service process to complete"
     echo "... waiting ..."
@@ -72,7 +72,7 @@ do
     # Update domain in core DB
     echo "Updating domain table."
     update="update domain set origin='$new_origin' where \"serviceName\"='$service_instance';"
-    psql ${DB_URI} -c "$update"`
+    psql ${DB_URI} -c "$update"
     echo
   fi
 

--- a/pages/update-cdn-origins.sh
+++ b/pages/update-cdn-origins.sh
@@ -14,16 +14,23 @@ then
   exit 0
 fi
 
+max_rows=${1:--1}
+
+offset=${2:-0}
+
+
+[ -z "${CF_API_URI}"  ] && echo -e "\n Required CF_API_URI environment variable is not set\n";  exit 1
+[ -z "${CF_USERNAME}" ] && echo -e "\n Required CF_USERNAME environment variable is not set\n"; exit 1
+[ -z "${CF_PASSWORD}" ] && echo -e "\n Required CF_PASSWORD environment variable is not set\n"; exit 1
+[ -z "${CF_ORG}"      ] && echo -e "\n Required CF_ORG environment variable is not set\n"; exit 1
+[ -z "${CF_SPACE}"    ] && echo -e "\n Required CF_SPACE environment variable is not set\n"; exit 1
+[ -z "${DB_URI}"      ] && echo -e "\n Required DB_URI environment variable is not set\n"; exit 1
+
 # CF Auth
 cf api "${CF_API_URL}"
 (set +x; cf auth "${CF_USERNAME}" "${CF_PASSWORD}")
 
-cf target -o "${CF_ORG}"
-
-
-max_rows=${1:--1}
-
-offset=${2:-0}
+cf target -o "${CF_ORG}" -s "${CF_SPACE}"
 
 # Waiting for service instance to finish being processed.
 wait_for_service_instance() {

--- a/pages/update-cdn-origins.sh
+++ b/pages/update-cdn-origins.sh
@@ -43,9 +43,9 @@ wait_for_service_instance() {
 
 # Find domains that need to be updated and iterate through them
 domains_processed=0
-query="select \"serviceName\",origin from domain where state='provisioned' and origin like '%app.cloud.gov';"
+query="select id,\"serviceName\",origin from domain where state='provisioned' and origin like '%app.cloud.gov';"
 domains=`psql ${DB_URI} --csv -t -c "$query"`
-while IFS="," read -r service_instance current_origin
+while IFS="," read -r id service_instance current_origin
 do
   ((domains_processed++))
 
@@ -71,7 +71,7 @@ do
 
     # Update domain in core DB
     echo "Updating domain table."
-    update="update domain set origin='$new_origin' where \"serviceName\"='$service_instance';"
+    update="update domain set origin='$new_origin' where \"id\"='$id';"
     psql ${DB_URI} -c "$update"
     echo
   fi

--- a/pages/update-cdn-origins.sh
+++ b/pages/update-cdn-origins.sh
@@ -42,14 +42,14 @@ wait_for_service_instance() {
 }
 
 # Find domains that need to be updated and iterate through them
-rows_processed=0
+domains_processed=0
 query="select \"serviceName\",origin from domain where state='provisioned' and origin like '%app.cloud.gov';"
 domains=`psql ${DB_URI} --csv -t -c "$query"`
 while IFS="," read -r service_instance current_origin
 do
-  ((rows_processed++))
+  ((domains_processed++))
 
-  if [[ ($max_domains -gt 0) && ($rows_processed -gt $max_domains)]]
+  if [[ ($max_domains -gt 0) && ($domains_processed -gt $max_domains)]]
   then
     break
   fi
@@ -78,4 +78,4 @@ do
 
 done <<< $domains
 
-echo "Done. Processed rows: $rows_processed"
+echo "Done. Processed domains: $domains_processed"

--- a/pages/update-cdn-origins.sh
+++ b/pages/update-cdn-origins.sh
@@ -45,7 +45,7 @@ wait_for_service_instance() {
 }
 
 rows_processed=0
-query="select \"serviceName\",origin from domain where state='provisioned';"
+query="select \"serviceName\",origin from domain where state='provisioned' and origin like '%app.cloud.gov';"
 domains=`psql ${DB_URI} --csv -t -c "$query"`
 while IFS="," read -r service_instance current_origin
 do

--- a/pages/update-cdn-origins.sh
+++ b/pages/update-cdn-origins.sh
@@ -66,7 +66,7 @@ do
 
     # Wait for update-service process to complete"
     echo "... waiting ..."
-    wait_for_service_instance $SERVICE_INSTANCE
+    wait_for_service_instance $service_instance
     echo "Service instance updated."
 
     # Update domain in core DB
@@ -75,6 +75,7 @@ do
     psql ${DB_URI} -c "$update"`
     echo
   fi
+
 done <<< $domains
 
 echo "Done. Processed rows: $rows_processed"

--- a/pages/update-cdn-origins.sh
+++ b/pages/update-cdn-origins.sh
@@ -37,7 +37,6 @@ wait_for_service_instance() {
   done
 }
 
-# TODO: Eliminate SQL output and instead update DB from within primary loop
 rows_processed=0
 query="select \"serviceName\",origin from domain where state='provisioned';"
 domains=`psql ${DB_URI} --csv -t -c "$query"`
@@ -64,17 +63,12 @@ do
     # For the moment, outputting instead of executing this command...
     echo "cf update-service $service_instance -c '{\"origin\": \"$new_origin\"}'"
 
-    # ... and since we're not executing that we're not yet going to
     # wait_for_service_instance $SERVICE_INSTANCE"
+    echo "wait_for_service_instance $SERVICE_INSTANCE"
 
-    # Here's the SQL we'll need to run to update the database once the origin is updated
-    SQL+="update domain set origin='$new_origin' where \"serviceName\"='$service_instance';"$'\n'
+    update="update domain set origin='$new_origin' where \"serviceName\"='$service_instance';"
+    # psql ${DB_URI} -c "$update"`
+    echo "psql DB_URI -c \"$update\""
+    echo
   fi
 done <<< $domains
-
-# TODO: Ensure that this happens even if an error occurs in the loop above
-if [[ ${#SQL} -gt 0 ]]
-then
-  echo -e "\nThe following SQL will need to be executed against the database:\n"
-  echo "$SQL"
-fi


### PR DESCRIPTION
**WORK IN PROGRESS** towards cloud-gov/pages-core#4015

Adds `pages/update-cdn-origins.sh` which retrieves domains from the `domain` table, updates the CDN origin as necessary via `cf update-service` to update the CDN origin from Federalist to cloud.gov Pages standard, and updates the `domain` table with the new origin.

The script is expected to be run from a jumpbox environment from which it can access the sites space in Cloud Foundry and the relevant database.

It requires six environment variables:
- `CF_API_URI`
- `CF_USERNAME`
- `CF_PASSWORD`
- `CF_ORG`
- `CF_SPACE`
- `DB_URI`

And it takes one optional command line argument: 
```
update-cdn-origins.sh [max-domains]
```
`max-domains` allows execution to be limited to specific number of domains rather than processing all unprocessed domains in the `domain` table.

## Changes proposed in this pull request:
- Adds `pages/update-cdn-origins.sh`

## security considerations
No scripts are introduced into the running codebase. This is a script for use by administrators under specific circumstances.