### PR TITLE
Hotfix to Pages domain origin update script

### DIFF
--- a/pages/update-cdn-origins.sh
+++ b/pages/update-cdn-origins.sh
@@ -17,12 +17,12 @@ fi
 max_domains=${1:--1}
 
 # Check for required environment variables
-[ -z "${CF_API_URI}"  ] && echo -e "\n Required CF_API_URI environment variable is not set\n";  exit 1
-[ -z "${CF_USERNAME}" ] && echo -e "\n Required CF_USERNAME environment variable is not set\n"; exit 1
-[ -z "${CF_PASSWORD}" ] && echo -e "\n Required CF_PASSWORD environment variable is not set\n"; exit 1
-[ -z "${CF_ORG}"      ] && echo -e "\n Required CF_ORG environment variable is not set\n"; exit 1
-[ -z "${CF_SPACE}"    ] && echo -e "\n Required CF_SPACE environment variable is not set\n"; exit 1
-[ -z "${DB_URI}"      ] && echo -e "\n Required DB_URI environment variable is not set\n"; exit 1
+[ -z "${CF_API_URI}"  ] && { echo -e "\n Required CF_API_URI environment variable is not set\n";  exit 1; }
+[ -z "${CF_USERNAME}" ] && { echo -e "\n Required CF_USERNAME environment variable is not set\n"; exit 1; }
+[ -z "${CF_PASSWORD}" ] && { echo -e "\n Required CF_PASSWORD environment variable is not set\n"; exit 1; }
+[ -z "${CF_ORG}"      ] && { echo -e "\n Required CF_ORG environment variable is not set\n"; exit 1; }
+[ -z "${CF_SPACE}"    ] && { echo -e "\n Required CF_SPACE environment variable is not set\n"; exit 1; }
+[ -z "${DB_URI}"      ] && { echo -e "\n Required DB_URI environment variable is not set\n"; exit 1; }
 
 # Authenticate and set Cloud Foundry target
 cf api "${CF_API_URI}"

--- a/pages/update-cdn-origins.sh
+++ b/pages/update-cdn-origins.sh
@@ -47,7 +47,7 @@ query="select id,\"serviceName\",origin from domain where state='provisioned' an
 domains=`psql ${DB_URI} --csv -t -c "$query"`
 while IFS="," read -r id service_instance current_origin
 do
-  ((domains_processed++))
+  let "domains_processed=$domains_processed + 1"
 
   if [[ ($max_domains -gt 0) && ($domains_processed -gt $max_domains)]]
   then


### PR DESCRIPTION
A couple of details in the script merged with #237 didn't work as expected when run as a script in the jumpbox environment. I believe this will resolve that.

## Changes proposed in this pull request:
- One syntax change, and one bug fix in `pages/update-cdn-origins.sh`

## security considerations
None. No changes are introduced into the running codebase. This is a script for use by administrators under specific circumstances.