### PR TITLE
add script to prune CW log groups

### DIFF
--- a/aws/cloudwatch/prune-cloudwatch-log-groups.sh
+++ b/aws/cloudwatch/prune-cloudwatch-log-groups.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
 
+LOG_GROUP_NAME_PREFIX="$1"
+if [[ -z "$LOG_GROUP_NAME_PREFIX" ]]; then
+  echo "log group name prefix is required as first argument"
+  exit 1
+fi
+
 minimum_log_age_for_deletion="30m"
 
-for log_group_name in $(aws logs describe-log-groups --log-group-name-prefix "$1" | jq -r '.logGroups[].logGroupName'); do
+for log_group_name in $(aws logs describe-log-groups --log-group-name-prefix "$LOG_GROUP_NAME_PREFIX" | jq -r '.logGroups[].logGroupName'); do
   latest_event_timestamp=$(aws logs describe-log-streams --log-group-name "$log_group_name" \
     | jq -r '.logStreams | sort_by(.lastEventTimestamp) | last | .lastEventTimestamp')
   if (( (latest_event_timestamp / 1000) < $(date -v "-$minimum_log_age_for_deletion" +%s) )); then

--- a/aws/cloudwatch/prune-cloudwatch-log-groups.sh
+++ b/aws/cloudwatch/prune-cloudwatch-log-groups.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+minimum_log_age_for_deletion="30m"
+
+for log_group_name in $(aws logs describe-log-groups --log-group-name-prefix "$1" | jq -r '.logGroups[].logGroupName'); do
+  latest_event_timestamp=$(aws logs describe-log-streams --log-group-name "$log_group_name" \
+    | jq -r '.logStreams | sort_by(.lastEventTimestamp) | last | .lastEventTimestamp')
+  if (( (latest_event_timestamp / 1000) < $(date -v "-$minimum_log_age_for_deletion" +%s) )); then
+    echo "deleting $log_group_name"
+    aws logs delete-log-group --log-group-name "$log_group_name"
+  fi
+done


### PR DESCRIPTION
Related to https://github.com/cloud-gov/private/issues/732

## Changes proposed in this pull request:

- add script to prune CW log groups where the latest log event is older than 30 months

## security considerations

We're only pruning log groups where the latest event time is older than 30 months because we have an M-21-31 mandate to keep logs for at least 30 months. So deleting these log groups should not be in violation of our M-21-31 compliance.
