### PR TITLE
add script to set cw logs retention & update cw log group pruning script

### DIFF
--- a/aws/cloudwatch/prune-cloudwatch-log-groups.sh
+++ b/aws/cloudwatch/prune-cloudwatch-log-groups.sh
@@ -1,18 +1,58 @@
 #!/bin/bash
 
+function usage {
+cat >&2 <<EOM
+
+usage: $(basename "$0") <log-group-name-prefix>
+
+options:
+
+  $0 -d          Set this value if you want to delete log groups with no logs newer than the given timestamp
+  $0 -a          Set timestamp (in seconds) that will be used to flag log groups for deletion. Defaults to flagging log groups with no new logs in the last 30 months.
+
+Query AWS to find and optionally delete Cloudwatch log groups which don't have newer logs than the given timestamp.
+EOM
+}
+
+MINIMUM_LOG_AGE_TIMESTAMP=$(date -v "-30m" +%s)
+DELETE=0
+
+while getopts ":hda:" opt; do
+  case ${opt} in
+    h )
+      usage
+      exit 0
+      ;;
+    d )
+      DELETE=1
+      ;;
+    a )
+      MINIMUM_LOG_AGE_TIMESTAMP=$OPTARG
+      ;;
+    * )
+      echo "Invalid Option: $OPTARG"
+      usage
+      exit 1
+      ;;
+  esac
+done
+shift $((OPTIND -1))
+
 LOG_GROUP_NAME_PREFIX="$1"
 if [[ -z "$LOG_GROUP_NAME_PREFIX" ]]; then
   echo "log group name prefix is required as first argument"
   exit 1
 fi
 
-minimum_log_age_for_deletion="30m"
-
 for log_group_name in $(aws logs describe-log-groups --log-group-name-prefix "$LOG_GROUP_NAME_PREFIX" | jq -r '.logGroups[].logGroupName'); do
   latest_event_timestamp=$(aws logs describe-log-streams --log-group-name "$log_group_name" \
     | jq -r '.logStreams | sort_by(.lastEventTimestamp) | last | .lastEventTimestamp')
-  if (( (latest_event_timestamp / 1000) < $(date -v "-$minimum_log_age_for_deletion" +%s) )); then
-    echo "deleting $log_group_name"
-    aws logs delete-log-group --log-group-name "$log_group_name"
+  if (( (latest_event_timestamp / 1000) < MINIMUM_LOG_AGE_TIMESTAMP )); then
+    MINIMUM_LOG_AGE_DATE=$(date -r "$MINIMUM_LOG_AGE_TIMESTAMP")
+    echo "$log_group_name has no logs newer than $MINIMUM_LOG_AGE_DATE"
+    if (( DELETE > 0 )); then
+      echo "deleting $log_group_name"
+      aws logs delete-log-group --log-group-name "$log_group_name"
+    fi
   fi
 done

--- a/aws/cloudwatch/set-cloudwatch-retention.sh
+++ b/aws/cloudwatch/set-cloudwatch-retention.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+RETENTION_IN_DAYS=1096 # 3 years, minimum value that exceeds 30 months M-21-31 requirement
+
+for log_group_name in $(aws logs describe-log-groups | jq -r '.logGroups[] | select(.retentionInDays == null) | .logGroupName'); do
+  aws logs put-retention-policy --log-group-name "$log_group_name" --retention-in-days $RETENTION_IN_DAYS
+  echo "set retention policy for $log_group_name to $RETENTION_IN_DAYS days"
+done


### PR DESCRIPTION
## Changes proposed in this pull request:

- add script to set Cloudwatch logs retention policy on groups without a policy
- update Cloudwatch log group pruning script to be easier to use

## security considerations

None, these scripts just help reduce the cost of storing Cloudwatch logs unnecessarily past 36 months.
