### PR TITLE
Prometheus/grafana switched to new versions of exporters

### DIFF
--- a/parse-nessus-xml.py
+++ b/parse-nessus-xml.py
@@ -205,7 +205,7 @@ for filename in filenames:
                     if re.search(rf'/var/vcap/bosh/bin/(bosh-agent|monit)', line):
                         daemon_count += 1
                         continue
-                    if re.search(rf'^/var/vcap/data/packages/({DAEMONS})2?/[0-9a-f]+/(s?bin/)?({DAEMONS})(-server|-asg-syncer)?$', line):
+                    if re.search(rf'^/var/vcap/data/packages/({DAEMONS})(2|-attic)?/[0-9a-f]+/(s?bin/)?({DAEMONS})(-server|-asg-syncer)?$', line):
                         daemon_count += 1
                         continue
                     # allow java and node for idp, ELK


### PR DESCRIPTION
## Changes proposed in this pull request:
-
- Prometheus/grafana switched to new versions of exporters, so we've appended `-attic` to ours 
-

## security considerations
Tested that this does not otherwise change parser output.
