### PR TITLE
Reset org, space, instance ids between iterations

### DIFF
--- a/aws/aws-list-unused-es-domains.py
+++ b/aws/aws-list-unused-es-domains.py
@@ -99,6 +99,9 @@ def export_domains():
         arn = domain['DomainStatus']['ARN']
         tags = es_client.list_tags(ARN=arn)
 
+        # Pull the org and space id's from the tags
+        org_id = space_id = instance_guid = ""
+
         for tag in tags['TagList']:
             if tag['Key'] == "Organization GUID":
                 org_id = tag['Value']


### PR DESCRIPTION
## Changes proposed in this pull request:
- Blanks out the org, space and instance guids pulled from the tags, otherwise if the tags are missing from the current cluster, the last cluster's values are used.  Not all clusters/domains have tags.
-
-

## security considerations
Helps make sure we are pulling info associated to the correct org/space.
