### PR TITLE
Fixes findings for conmon

### DIFF
--- a/parse-nessus-xml.py
+++ b/parse-nessus-xml.py
@@ -99,6 +99,7 @@ DAEMONS = """
     doomsday
     doppler
     elasticsearch_exporter
+    eventgenerator
     file.server
     firehose_exporter
     forwarder-agent
@@ -118,6 +119,7 @@ DAEMONS = """
     loggregator_trafficcontroller
     metrics-agent
     metrics-discovery-registrar
+    metricsforwarder
     netmon
     nginx
     nginx_prometheus
@@ -125,7 +127,7 @@ DAEMONS = """
     node_exporter
     ntp
     oauth2.proxy
-    opt
+    operator
     policy-server
     policy-server-internal
     prom.scraper
@@ -139,6 +141,7 @@ DAEMONS = """
     rlp
     rlp-gateway
     route.emitter
+    scalingengine
     secureproxy
     service-discovery-controller
     silk-controller
@@ -205,11 +208,14 @@ for filename in filenames:
                     if re.search(rf'/var/vcap/bosh/bin/(bosh-agent|monit)', line):
                         daemon_count += 1
                         continue
-                    if re.search(rf'^/var/vcap/data/packages/({DAEMONS})2?/[0-9a-f]+/(s?bin/)?({DAEMONS})(-server|-asg-syncer)?$', line):
+                    if re.search(rf'^/var/vcap/data/packages/({DAEMONS})(2|-attic)?/[0-9a-f]+/(s?bin/)?({DAEMONS})(-server|-asg-syncer)?$', line):
+                        daemon_count += 1
+                        continue
+                    if re.search(rf'^/var/vcap/data/packages/golangapiserver/[0-9a-f]+/api$', line):
                         daemon_count += 1
                         continue
                     # allow java and node for idp, ELK
-                    if re.search(rf'^/var/vcap/data/packages/(elasticsearch|idp|kibana|kibana-platform|openjdk_1.8.0|openjdk-11|uaa)/[/[0-9a-z]+/bin/(java|node)$', line):
+                    if re.search(rf'^/var/vcap/data/packages/(elasticsearch|idp|kibana|kibana-platform|openjdk_1.8.0|openjdk[-_]11(.0)?|openjdk-17|uaa)/[/[0-9a-z]+/bin/(java|node)$', line):
                         daemon_count += 1
                         continue
                     # nats daemons are OK on nats and bosh


### PR DESCRIPTION
## Changes proposed in this pull request:
-
- Replaces #277
Before:

```
❯ nessus_daemons
File name: /Users/peterdburkholder/Documents/ConMon/2023/10/Production-and-Tooling-Vulnerability-and-Compliance-scans_2023-10-25/Production_Vulnerability_scan_i6srdj.nessus
File size: 75.6 MiB
Scan start date: 2023-10-25 03:02:19
File name: /Users/peterdburkholder/Documents/ConMon/2023/10/Production-and-Tooling-Vulnerability-and-Compliance-scans_2023-10-25/Tooling_Vulnerability_scan_zxvgrw.nessus
File size: 13.8 MiB
Scan start date: 2023-10-25 02:01:59

------- Daemon REPORT  ------

Known deamons seen:  2420
Unknown deamons:
app-autoscaler-apiserver-0-cf-production :  /var/vcap/data/packages/golangapiserver/d040224cc6e3995c61b8b2324cb360c9cc808f3c/api
app-autoscaler-apiserver-1-cf-production :  /var/vcap/data/packages/golangapiserver/d040224cc6e3995c61b8b2324cb360c9cc808f3c/api
app-autoscaler-eventgenerator-0-cf-production :  /var/vcap/data/packages/eventgenerator/943f354a2d9a325912ad8be1994591d3c710fe0c/eventgenerator
app-autoscaler-eventgenerator-1-cf-production :  /var/vcap/data/packages/eventgenerator/943f354a2d9a325912ad8be1994591d3c710fe0c/eventgenerator
app-autoscaler-metricsforwarder-0-cf-production :  /var/vcap/data/packages/metricsforwarder/ec37090c9018e74b87108e9ea470bb43d707f4ae/metricsforwarder
app-autoscaler-metricsforwarder-1-cf-production :  /var/vcap/data/packages/metricsforwarder/ec37090c9018e74b87108e9ea470bb43d707f4ae/metricsforwarder
app-autoscaler-operator-0-cf-production :  /var/vcap/data/packages/operator/195136142d056715f09cd1f85953c8a9d00b50c2/operator
app-autoscaler-operator-1-cf-production :  /var/vcap/data/packages/operator/195136142d056715f09cd1f85953c8a9d00b50c2/operator
app-autoscaler-scalingengine-0-cf-production :  /var/vcap/data/packages/scalingengine/f5e2dc7da463b4b101288546d42cf572f376343b/scalingengine
app-autoscaler-scalingengine-1-cf-production :  /var/vcap/data/packages/scalingengine/f5e2dc7da463b4b101288546d42cf572f376343b/scalingengine
app-autoscaler-scheduler-0-cf-production :  /var/vcap/data/packages/openjdk-17/335e8fe026f45cb17d85abe0bafa4e3a041fc4b2/bin/java
app-autoscaler-scheduler-1-cf-production :  /var/vcap/data/packages/openjdk-17/335e8fe026f45cb17d85abe0bafa4e3a041fc4b2/bin/java
credhub-production-credhub-0-cf-tooling :  /var/vcap/data/packages/openjdk_11.0/62cbdfe2b2acceabeace86a7445fa557c2f320ab/jre/bin/java
credhub-production-credhub-1-cf-tooling :  /var/vcap/data/packages/openjdk_11.0/62cbdfe2b2acceabeace86a7445fa557c2f320ab/jre/bin/java
credhub-production-credhub-2-cf-tooling :  /var/vcap/data/packages/openjdk_11.0/62cbdfe2b2acceabeace86a7445fa557c2f320ab/jre/bin/java
credhub-staging-credhub-0-cf-tooling :  /var/vcap/data/packages/openjdk_11.0/62cbdfe2b2acceabeace86a7445fa557c2f320ab/jre/bin/java
credhub-staging-credhub-1-cf-tooling :  /var/vcap/data/packages/openjdk_11.0/62cbdfe2b2acceabeace86a7445fa557c2f320ab/jre/bin/java
developmentbosh-bosh-0-cf-tooling :  /var/vcap/data/packages/openjdk_11.0/62cbdfe2b2acceabeace86a7445fa557c2f320ab/jre/bin/java
productionbosh-bosh-0-cf-tooling :  /var/vcap/data/packages/openjdk_11.0/62cbdfe2b2acceabeace86a7445fa557c2f320ab/jre/bin/java
prometheus-staging-prometheus-0-cf-tooling :  /var/vcap/data/packages/firehose_exporter-attic/0c37301a9a85aa39c6b5c5017f04fa3d893a8fc8/bin/firehose_exporter
stagingbosh-bosh-0-cf-tooling :  /var/vcap/data/packages/openjdk_11.0/62cbdfe2b2acceabeace86a7445fa557c2f320ab/jre/bin/java
toolingbosh-bosh-0-cf-tooling :  /var/vcap/data/packages/openjdk_11.0/f9249c98dc2ad12064fcd9842bc5b1d5eb888c5a/jre/bin/java
```

After:

```
❯ nessus_daemons
File name: /Users/peterdburkholder/Documents/ConMon/2023/10/Production-and-Tooling-Vulnerability-and-Compliance-scans_2023-10-25/Production_Vulnerability_scan_i6srdj.nessus
File size: 75.6 MiB
Scan start date: 2023-10-25 03:02:19
File name: /Users/peterdburkholder/Documents/ConMon/2023/10/Production-and-Tooling-Vulnerability-and-Compliance-scans_2023-10-25/Tooling_Vulnerability_scan_zxvgrw.nessus
File size: 13.8 MiB
Scan start date: 2023-10-25 02:01:59

------- Daemon REPORT  ------

Known deamons seen:  2442
Unknown deamons:
```

## security considerations
Safe. Fixes spurious findings from new components.
