### PR TITLE
Update CF role scripts

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,1 @@
+external-sources=true

--- a/cf-get-user-roles.sh
+++ b/cf-get-user-roles.sh
@@ -50,10 +50,10 @@ for result in $ORG_SPACE_RESULTS; do
   role=$(echo "$result" | awk -F "," '{print $1}')
   
   ORG_GUID=$(echo "$result" | awk -F "," '{print $2}')
-  org_name=$(query_org "$ORG_GUID")
+  org_name=$(query_org_name "$ORG_GUID")
 
   SPACE_GUID=$(echo "$result" | awk -F "," '{print $3}')
-  space_name=$(query_space "$SPACE_GUID")
+  space_name=$(query_space_name "$SPACE_GUID")
 
   output="$role:"
   if [[ -n "$org_name" ]]; then

--- a/cf-get-user-roles.sh
+++ b/cf-get-user-roles.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# import common functions
+
+source "$(dirname "${BASH_SOURCE[0]}")/lib/cf.sh"
+
 # Grabs all cf org and space roles for a user
 
 set -e
@@ -26,20 +30,6 @@ if [ "$cf_version" -lt "$min_cf_version" ]; then
 
   exit 1
 fi
-
-function query_org {
-  if [ -n "$ORG_GUID" ]; then
-    ORG_NAME=$(cf curl "/v3/organizations/$ORG_GUID" | jq -r '.name')
-    echo "$ORG_NAME"
-  fi
-}
-
-function query_space {
-  if [ -n "$SPACE_GUID" ]; then
-    SPACE_NAME=$(cf curl "/v3/spaces/$SPACE_GUID" | jq -r '.name')
-    echo "$SPACE_NAME"
-  fi
-}
 
 username=$1
 

--- a/lib/cf.sh
+++ b/lib/cf.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+function query_org {
+  if [ -n "$ORG_GUID" ]; then
+    ORG_NAME=$(cf curl "/v3/organizations/$ORG_GUID" | jq -r '.name')
+    echo "$ORG_NAME"
+  fi
+}
+
+function query_space {
+  if [ -n "$SPACE_GUID" ]; then
+    SPACE_NAME=$(cf curl "/v3/spaces/$SPACE_GUID" | jq -r '.name')
+    echo "$SPACE_NAME"
+  fi
+}

--- a/lib/cf.sh
+++ b/lib/cf.sh
@@ -1,15 +1,22 @@
 #!/bin/bash
 
-function query_org {
+function query_org_name {
   if [ -n "$ORG_GUID" ]; then
     ORG_NAME=$(cf curl "/v3/organizations/$ORG_GUID" | jq -r '.name')
     echo "$ORG_NAME"
   fi
 }
 
-function query_space {
+function query_space_name {
   if [ -n "$SPACE_GUID" ]; then
     SPACE_NAME=$(cf curl "/v3/spaces/$SPACE_GUID" | jq -r '.name')
     echo "$SPACE_NAME"
+  fi
+}
+
+function query_service_instance_name {
+  if [ -n "$INSTANCE_GUID" ]; then
+    SERVICE_NAME=$(cf curl "/v3/service_instances/$INSTANCE_GUID"  | jq -r '.name')
+    echo "$SERVICE_NAME"
   fi
 }

--- a/services/aws-instance-info.sh
+++ b/services/aws-instance-info.sh
@@ -34,7 +34,7 @@ function query_rds {
   echo ${output}
 }
 
- function query_es {
+function query_es {
   local service_key=$1
   # get the db instance name
   local hostname=$(echo $service_key | jq -r .host)
@@ -49,7 +49,7 @@ function query_rds {
   echo ${output}
 }
 
- function query_redis {
+function query_redis {
   local service_key=$1
   # get the db instance name
   local hostname=$(echo $service_key | jq -r .host)

--- a/strip-user-org-and-space-roles.sh
+++ b/strip-user-org-and-space-roles.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
-shopt -s inherit_errexit
+shopt -s inherit_errexit || true
 
 main() {
   [[ $# -eq 3 ]] || usage "Expected three arguments, got $#"


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update cf-get-user-roles.sh to return a list of roles with the names of orgs/spaces rather than GUIDs. The output format is no longer CSV.

    Before:
    
    ```shell
    role                  org_uuid                                space_uuid
    "organization_user"  "abc-123"  "null"
    "organization_user"  "def-456"  "null"
    "space_manager"      "null"                                  "ghi-789"
    ```
    
    After:
    
    ```shell
    organization_user: org-1
    organization_user: org-1
    space_manager: space1
    space_developer: space1
    ```
- Move helper scripts for querying CF API to `lib/cf.sh`
- Refactor scripts to use shared CF API helpers
- Add .shellcheckrc to suppress https://www.shellcheck.net/wiki/SC1091
- Update `strip-user-org-and-space-roles.sh` to suppress errors on older BASH versions

## security considerations

None, just refactoring and improving helper scripts
