### PR TITLE
Add defect dojo daemon for parse-nessus

### DIFF
--- a/parse-nessus-xml.py
+++ b/parse-nessus-xml.py
@@ -211,6 +211,10 @@ for filename in filenames:
                     if re.search(rf'^/var/vcap/data/packages/({DAEMONS})(2|-attic)?/[0-9a-f]+/(s?bin/)?({DAEMONS})(-server|-asg-syncer)?$', line):
                         daemon_count += 1
                         continue
+                    # add defect dojo
+                    if re.search(rf'^/var/vcap/data/packages/godojo/[0-9a-f]+/bin/bin/uwsgi$', line):
+                        daemon_count += 1
+                        continue
                     if re.search(rf'^/var/vcap/data/packages/golangapiserver/[0-9a-f]+/api$', line):
                         daemon_count += 1
                         continue

--- a/parse-nessus-xml.py
+++ b/parse-nessus-xml.py
@@ -187,7 +187,7 @@ for filename in filenames:
             elif float(cvss3_base_score) >= 7.0:
                 cvss3_risk_factor = "High"
             elif float(cvss3_base_score) >= 4.0:
-                cvss3_risk_factor = "Moderate"
+                cvss3_risk_factor = "Medium"
             elif float(cvss3_base_score) > 0.1:
                 cvss3_risk_factor = "Low"
             else:
@@ -322,7 +322,7 @@ if report_csv:
             cvss3_base_score = vuln_report[vuln]["cvss3_base_score"]
             cvss3_risk_factor = vuln_report[vuln]["cvss3_risk_factor"]
             if cvss3_risk_factor == "Critical":
-                cvss3_risk_factor = "High"
+                cvss3_risk_factor = "High"      # Critical is not a valid FedRAMP® POA&M risk
             weakness_name=vuln_report[vuln]["plugin_name"]
             csvwriter.writerow( [
                 "CGXX", 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Updates summary output to match format from CVSSv2
- Moves CVSSv3 logic to parsing step, not output step
- Add defect dojo daemon regex for deamon check
- Use "Medium" not "Moderate" risk

## security considerations
Safe. Approved new services.
