### PR TITLE
Add sandbox restore script

### DIFF
--- a/cloudfoundry/restore-sandbox-spaces.sh
+++ b/cloudfoundry/restore-sandbox-spaces.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+INPUT_FILE=$1
+
+ADMIN=$(cf target | grep -i user | awk '{print $2}')
+
+while read -r line; do
+  IFS=';' read -r -a array <<< "$line"
+  SPACE_NAME="${array[0]}"
+  ORG_NAME="${array[1]}"
+  DEVELOPERS="${array[2]}"
+  MANAGERS="${array[3]}"
+
+  echo "recreating sandbox space $SPACE_NAME in org $ORG_NAME"
+
+  cf create-space "$SPACE_NAME" -o "$ORG_NAME" -q "sandbox_quota"
+  
+  if [[ -n "$DEVELOPERS" ]]; then
+    echo "recreating sandbox space developers in space $SPACE_NAME, org $ORG_NAME"
+    for developer in $DEVELOPERS; do
+      cf set-space-role "$developer" "$ORG_NAME" "$SPACE_NAME" SpaceDeveloper
+    done
+  fi
+
+  if [[ -n "$MANAGERS" ]]; then
+    echo "recreating sandbox space managers in space $SPACE_NAME, org $ORG_NAME"
+    for manager in $MANAGERS; do
+      cf set-space-role "$manager" "$ORG_NAME" "$SPACE_NAME" SpaceManager
+    done
+  fi
+
+  # creator added by default - undo
+  cf unset-space-role "$ADMIN" "$ORG_NAME" "$SPACE_NAME" SpaceManager
+  cf unset-space-role "$ADMIN" "$ORG_NAME" "$SPACE_NAME" SpaceDeveloper
+
+  printf "\n"
+
+done < "$INPUT_FILE"

--- a/email/example-addresses.txt
+++ b/email/example-addresses.txt
@@ -1,2 +1,2 @@
-recipient@cloud.gov;space-1;org-1
-recipient@gsa.gov;space-2;org-1
+space-1;org-1;recipient@cloud.gov
+space-2;org-1;recipient@gsa.gov

--- a/email/send.sh
+++ b/email/send.sh
@@ -35,17 +35,17 @@ while read -r line; do
 
 	cp template.html "$MESSAGE"
 
-	# edit message.html in-place to replace the "%email" placeholder with the recipient address.
-	EMAIL="${array[0]}"
-	sed -e "s/%email/${EMAIL}/g" -i "" "$MESSAGE"
-
 	# this is an example of how you can replace "%space" in the template.html file with more custom data
-	SPACE_NAME="${array[1]}"
+	SPACE_NAME="${array[0]}"
 	sed -e "s/%space/${SPACE_NAME}/g" -i "" "$MESSAGE"
 
 	# this is an example of how you can replace "%org" in the template.html file with more custom data
-	ORG_NAME="${array[2]}"
+	ORG_NAME="${array[1]}"
 	sed -e "s/%org/${ORG_NAME}/g" -i "" "$MESSAGE"
+
+	# edit message.html in-place to replace the "%email" placeholder with the recipient address.
+	EMAIL="${array[2]}"
+	sed -e "s/%email/${EMAIL}/g" -i "" "$MESSAGE"
 
 	msmtp -t < "$MESSAGE"
 done <addresses.txt


### PR DESCRIPTION
## Changes proposed in this pull request:

We occasionally have issues with our CI pipeline that purges sandboxes every 90 days recreating the sandboxes automatically, so I created this script to quickly restore those sandboxes.

Also adjusted the `email.sh` script for contacting customers so that it could use the same source data structure as the restore sandboxes script.

## security considerations

None
