### PR TITLE
make query to delete user TOTP do a case-insensitive

### DIFF
--- a/reset-totp.sh
+++ b/reset-totp.sh
@@ -19,7 +19,7 @@ address=$(bosh interpolate "${manifest}" --path /instance_groups/name=uaa/jobs/n
 password=$(bosh interpolate "${manifest}" --path /instance_groups/name=uaa/jobs/name=uaa/properties/uaadb/roles/name=cfdb/password)
 rm "${manifest}"
 
-psql "postgres://cfdb:${password}@${address}:5432/uaadb" -c "delete from totp_seed where username = '${totp_username}'"
+psql "postgres://cfdb:${password}@${address}:5432/uaadb" -c "delete from totp_seed where lower(username) = lower('${totp_username}')"
 
 echo "Successfully reset the totp for ${totp_username}. Please notify the user."
 echo "NOTE: Username is case-sensitive - if the user is unable to reset, recheck capitalization"


### PR DESCRIPTION
## Changes proposed in this pull request:

- make query to delete user TOTP do a case-insensitive by using PostgreSQL `lower` function


## security considerations

None, just making this script easier to use so that a username will be deleted regardless of what case the username is entered as
