### PR TITLE
update reset TOTP script to better handle usernames with single quotes

### DIFF
--- a/reset-totp.sh
+++ b/reset-totp.sh
@@ -5,21 +5,23 @@ set -eu
 if [ "$#" -ne 2 ]; then
   script=$(basename "$0")
   echo "Usage: ${script} <deployment> <username>"
+  echo "If the username has a single quote in it, then wrap the value in double quotes (e.g. \"O'Test@gsa.gov\")"
   exit 1
 fi
 
 deployment=$1
-# Username is case-sensitive - make it lower-case
-#totp_username=$(echo $2 | tr '[A-Z]' '[a-z]')
 totp_username=$2
 
 manifest=$(mktemp)
-bosh -d ${deployment} manifest > "${manifest}"
+bosh -d "${deployment}" manifest > "${manifest}"
 address=$(bosh interpolate "${manifest}" --path /instance_groups/name=uaa/jobs/name=uaa/properties/uaadb/address)
 password=$(bosh interpolate "${manifest}" --path /instance_groups/name=uaa/jobs/name=uaa/properties/uaadb/roles/name=cfdb/password)
 rm "${manifest}"
 
-psql "postgres://cfdb:${password}@${address}:5432/uaadb" -c "delete from totp_seed where username = '${totp_username}'"
+# For usernames with single quotes (e.g. "O'Foobar@gsa.gov"), the single quotes have to be escaped for
+# PostgreSQL by replacing them with double single quotes
+escaped_username=${totp_username//\'/\'\'}
+psql "postgres://cfdb:${password}@${address}:5432/uaadb" -c "delete from totp_seed where username = '${escaped_username}'"
 
 echo "Successfully reset the totp for ${totp_username}. Please notify the user."
 echo "NOTE: Username is case-sensitive - if the user is unable to reset, recheck capitalization"


### PR DESCRIPTION
## Changes proposed in this pull request:

- update reset TOTP script to better handle usernames with single quotes
- apply Shellcheck suggestions

## security considerations

I'm not sure if there are any risks to this way of passing escaped PostgreSQL parameters to the script that would allow for SQL or query injection. In theory, this script can only be run by operators on our database.
