### PR TITLE
add auditing scripts

### DIFF
--- a/audit/audit-opensearch-describe-domain-config.sh
+++ b/audit/audit-opensearch-describe-domain-config.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Disable AWS pager so output goes straight to console
+export AWS_PAGER=''
+
+for domain_name in $(aws opensearch list-domain-names --output json | jq -r '.DomainNames[].DomainName')
+do
+    aws opensearch describe-domain-config --domain-name "$domain_name" --output table
+done

--- a/audit/get-clamav-current-signature-versions.sh
+++ b/audit/get-clamav-current-signature-versions.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+for deployment in $(bosh deployments --json | jq -r '.Tables[].Rows[].name')
+do
+    echo "Working deployment: $deployment"
+    bosh -d $deployment ssh --results --column=Instance --column=Stdout -c "sudo /var/vcap/packages/clamav/bin/freshclam -V --config-file=/var/vcap/jobs/clamav/conf/freshclam.conf"
+done

--- a/audit/get-clamav-last-scan.sh
+++ b/audit/get-clamav-last-scan.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+for deployment in $(bosh deployments --json | jq -r '.Tables[].Rows[].name')
+do
+    echo "Working deployment: $deployment"
+    bosh -d $deployment ssh --results --column=Instance --column=Stdout -c "sudo tail /var/vcap/sys/log/clamav/sched.log | grep 'End Date'"
+done

--- a/bosh/restart-clamav.sh
+++ b/bosh/restart-clamav.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# This script takes in a BOSH deployment name and restarts clamd and freshclam on each vm in that deployment
+
+set -e
+
+if [ "$#" -lt 1 ]; then
+  echo
+  echo "Usage:"
+  echo "   ./restart-clamav.sh <deployment>"
+  echo
+  exit 1;
+fi
+
+deployment=$1
+
+for instance in $(bosh -d $deployment vms --json | jq -r '.Tables[].Rows[].instance');
+do
+bosh -d $deployment ssh ${instance} sudo monit restart clamd freshclam;
+done;


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add script to get list opensearch domain names
- Add scripts to list out clamav current signatures and last scanned dates
- Add script to restart clamav for all instances in a deployment. Useful if there is an issue with clamav getting new database definitions

## security considerations
Adding scripts for auditing purposes, and for clamav restart
