### PR TITLE
Periodically archive GSA sites to Drive for GSA retention purposes.

### DIFF
--- a/pages/archive-sites.sh
+++ b/pages/archive-sites.sh
@@ -30,10 +30,11 @@ TIMESTAMP=$(date "+%Y%m%d-%H%M")
 PREFIX="$TARGET/$TIMESTAMP" 
 mkdir -p "$PREFIX" || fail "Unable to create the target directory $PREFIX"
 
-for S in cdo.gov cfo.gov paymentaccuracy.gov cio.gov coffa.gov evaluation.gov fpc.gov statspolicy.gov fcsm.gov; do 
+#for S in cdo.gov cfo.gov paymentaccuracy.gov cio.gov coffa.gov evaluation.gov fpc.gov statspolicy.gov fcsm.gov; do 
+for S in cfo.gov paymentaccuracy.gov cio.gov coffa.gov evaluation.gov fpc.gov statspolicy.gov fcsm.gov; do 
   echo "=============="
   echo "STARTING SITE: $S"
   echo "=============="
   sleep 1
-  mirror $S 
+  mirror $S || echo "exit status $?, continuing"
 done

--- a/pages/archive-sites.sh
+++ b/pages/archive-sites.sh
@@ -1,0 +1,39 @@
+#! /bin/bash 
+
+set -e
+
+function fail() {
+	echo $@
+	exit 1
+}
+
+function mirror() {
+	set -x
+	local site=$1
+	 wget --recursive \
+	       --directory-prefix="$PREFIX" \
+           --page-requisites \
+           --adjust-extension \
+           --span-hosts \
+           --convert-links \
+           --domains $site \
+           --no-parent https://www.$site
+	set +x
+}
+
+TARGET="$HOME/Google Drive/Shared drives/Cloud.gov Public/IDCDB-archive"
+
+[ -d "$TARGET" ] || fail "Cannot access Google Drive target $TARGET"
+
+TIMESTAMP=$(date "+%Y%m%d-%H%M")
+
+PREFIX="$TARGET/$TIMESTAMP" 
+mkdir -p "$PREFIX" || fail "Unable to create the target directory $PREFIX"
+
+for S in cdo.gov cfo.gov paymentaccuracy.gov cio.gov coffa.gov evaluation.gov fpc.gov statspolicy.gov fcsm.gov; do 
+  echo "=============="
+  echo "STARTING SITE: $S"
+  echo "=============="
+  sleep 1
+  mirror $S 
+done

--- a/pages/archive-sites.sh
+++ b/pages/archive-sites.sh
@@ -2,6 +2,7 @@
 
 # Periodically archive GSA "MY" sites to Drive for GSA retention purposes
 # for IDCDB: OGP IT Services Branch
+# Why "MY"? It's the GSA codes for: Office of Shared Solutions and Performance Improvement (OGP-MY)
 
 # This script uses `wget` to mirror the sites in question, 
 # and rewrites links so they're internally consistent

--- a/pages/archive-sites.sh
+++ b/pages/archive-sites.sh
@@ -1,5 +1,13 @@
 #! /bin/bash 
 
+# Periodically archive GSA "MY" sites to Drive for GSA retention purposes
+# for IDCDB: OGP IT Services Branch
+
+# This script uses `wget` to mirror the sites in question, 
+# and rewrites links so they're internally consistent
+# Assumes you have Google Drive installed so you can save content to a common location
+# See also: https://cloud-gov-new.zendesk.com/agent/tickets/11194
+
 set -e
 
 function fail() {
@@ -21,17 +29,18 @@ function mirror() {
 	set +x
 }
 
+which wget || fail "Need to install wget, e.g., 'brew install wget'"
+
 TARGET="$HOME/Google Drive/Shared drives/Cloud.gov Public/IDCDB-archive"
 
 [ -d "$TARGET" ] || fail "Cannot access Google Drive target $TARGET"
 
-TIMESTAMP=$(date "+%Y%m%d-%H%M")
+TIMESTAMP=$(date "+%Y%m%d")
 
 PREFIX="$TARGET/$TIMESTAMP" 
 mkdir -p "$PREFIX" || fail "Unable to create the target directory $PREFIX"
 
-#for S in cdo.gov cfo.gov paymentaccuracy.gov cio.gov coffa.gov evaluation.gov fpc.gov statspolicy.gov fcsm.gov; do 
-for S in cfo.gov paymentaccuracy.gov cio.gov coffa.gov evaluation.gov fpc.gov statspolicy.gov fcsm.gov; do 
+for S in cdo.gov cfo.gov paymentaccuracy.gov cio.gov coffa.gov evaluation.gov fpc.gov statspolicy.gov fcsm.gov; do 
   echo "=============="
   echo "STARTING SITE: $S"
   echo "=============="


### PR DESCRIPTION
## Changes proposed in this pull request:
-
- GSA OGP and Records Management wanted a way to get regular snapshots of the sites we host for them
- This script uses `wget` to mirror the sites in question, and rewrites links so they're internally consistent
- Assumes you have Google Drive installed so you can save content to a common location
- 

## security considerations
Safe. References publicly available websites, doesn't take any input, paths in Google Drive are innocuous
