### PR TITLE
add script to update plan visibility

### DIFF
--- a/cloudfoundry/update-plan-visiblity.sh
+++ b/cloudfoundry/update-plan-visiblity.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+if [ "$#" -ne 4 ]; then
+  echo
+  echo "Usage:"
+  echo "   update-plan-visibility.sh <list-of-org-names> <broker-name> <service-offering-name> <service-plan-name>"
+  echo
+  echo "where:"
+  echo "   - <list-of-org-names>: comma-separated list of org names"
+  echo "   - <broker-name>: name of broker providing service plan to update"
+  echo "   - <service-offering-name>: name of service offering containing plan to update"
+  echo "   - <service-plan-name>: service plan name to update"
+  echo
+  echo "Example:"
+  echo "   update-plan-visibility.sh org-1,org-2 broker-1 offering1 plan1"
+  exit 1
+fi
+
+ORG_NAMES=$1
+BROKER_NAME=$2
+SERVICE_OFFERING_NAME=$3
+SERVICE_PLAN_NAME=$4
+
+# FYI: doesn't handle pagination
+ORGS=$(cf curl "/v3/organizations?names=$ORG_NAMES&per_page=5000" | jq '[.resources[] | {guid, name}]')
+TMP_FILE=$(mktemp)
+cat > "${TMP_FILE}" << EOF
+{
+  "type": "organization",
+  "organizations": $ORGS
+}
+EOF
+
+for plan_guid in $(cf curl "/v3/service_plans?service_broker_names=$BROKER_NAME&service_offering_names=$SERVICE_OFFERING_NAME" | jq --arg service_plan_name "$SERVICE_PLAN_NAME" -r '.resources[] | select(.name==$service_plan_name) | .guid'); do
+  cf curl "/v3/service_plans/$plan_guid/visibility" \
+    -X PATCH \
+    -d "@$TMP_FILE"
+done
+
+rm "$TMP_FILE"


### PR DESCRIPTION
## Changes proposed in this pull request:

- add script to update plan visibility. It is especially useful when you need to change a service plan's visibility from `all` to a specific set of orgs

## security considerations

None. The script contents are not sensitive and it can only be run by platform admins
