### PR TITLE
update create org script to set label of org-type=customer

### DIFF
--- a/cloudfoundry/cf-create-org.sh
+++ b/cloudfoundry/cf-create-org.sh
@@ -99,6 +99,8 @@ ADMIN=$(cf target | grep -i user | awk '{print $2}')
 
 # Step 3: Create the org
 cf create-org "$ORG_NAME" -q "$HASHED_QUOTA_NAME"
+cf set-label org "$ORG_NAME" org-type=customer
+
 # creator added by default, which is usually not desirable
 cf unset-org-role "$ADMIN" "$ORG_NAME" OrgManager
 cf set-org-role "$MANAGER" "$ORG_NAME" OrgManager ${ORIGIN_FLAG:+"$ORIGIN_FLAG"}


### PR DESCRIPTION
## Changes proposed in this pull request:

- update create org script to set label of org-type=customer

Having a consistent label for customer orgs would allow us to [easily query for them using the CF API](https://v3-apidocs.cloudfoundry.org/version/3.188.0/index.html#labels-and-selectors) rather than relying on `grep` to exclude orgs by name, which is unreliable and brittle over time. We could update the script in https://github.com/cloud-gov/cg-scripts/pull/352 to use the label when querying

## security considerations

None. The script contents and these changes are not sensitive
