### PR TITLE
bulk update script added for license, contributions, and security mar…

### DIFF
--- a/github/bulk_update/README.md
+++ b/github/bulk_update/README.md
@@ -1,0 +1,232 @@
+# bulk_documentation_sync.py
+
+**Version:** v1 (2025-05-23)  
+**License:** MIT  
+**Maintainer:** Cloud.gov Office of Cybersecurity
+
+---
+
+## Overview
+
+`bulk_documentation_sync.py` is a command-line tool that automates the process of synchronizing three key documentation files across all repositories in a GitHub organization:
+
+- **CONTRIBUTING.md**
+- **LICENSE.md**
+- **SECURITY.md**
+
+It uses GitHub’s GraphQL API to:
+
+1. **Fetch** the canonical versions of those files (from a single “source” repository).
+2. **Enumerate** every non-archived, non-fork, non-template, non-private repository.
+3. **Compare** the checksum of each file on each repo’s default branch against the canonicals.
+4. **Create** a new branch (named with a timestamp and file list) when any file is missing or out of date.
+5. **Commit** all changed files in one atomic GraphQL mutation.
+6. **Open** a pull request with a clear title and body listing exactly which files were synchronized.
+7. **Log** every step as structured JSON to stdout and to a daily audit file, preventing duplicate PRs.
+
+An **audit mode** (`--audit`) will perform steps 1–3 and then simply list which repositories and files **would** be updated, without making any changes.
+
+---
+
+## Features
+
+- **Unlimited pagination**: reliably processes more than 100 repositories by using cursor-based GraphQL pagination ordered by repository name.
+- **Selective filtering**: skips archived, forked, template, and private repositories automatically.
+- **Audit log**: appends one JSON record per repository to `audit_update_docs_YYYYMMDD.jsonl`, ensuring each repo is only processed once per day.
+- **Audit mode**: with `--audit`, outputs “will_update” status and file list without creating branches or PRs.
+- **Existing-PR detection**: skips any repository that already has an open PR whose title begins with “Update docs:” (normal mode only).
+- **Structured logging**: emits JSON events (`canonical_fetched`, `page_fetched`, `start_processing`, etc.) to stdout for easy ingestion into centralized logging systems.
+- **Dynamic branch names & PRs**: branch names include the timestamp and file identifiers; PR titles and bodies list exactly which files were changed.
+- **GH CLI integration**: uses `gh auth token` for authentication if `GITHUB_TOKEN` is not set.
+
+---
+
+## Prerequisites
+
+1. **Python 3.8+**
+2. **`requests`** library
+   ```bash
+   pip install requests
+   ```
+
+````
+
+3. **GitHub CLI (`gh`)** (for authentication fallback)
+
+   ```bash
+   gh auth login
+   ```
+4. **Network access** to `api.github.com`
+
+---
+
+## Installation
+
+1. **Clone this repository** (or copy `bulk_documentation_sync.py` to your scripts folder).
+2. Ensure it’s executable:
+
+   ```bash
+   chmod +x bulk_documentation_sync.py
+   ```
+3. (Optional) Place it on your PATH or symlink it to `/usr/local/bin`.
+
+---
+
+## Usage
+
+```bash
+./bulk_documentation_sync.py --org <ORG> [options]
+```
+
+### Required
+
+* `--org <ORG>`
+  Your GitHub organization login (e.g. `cloud-gov`).
+
+### Optional
+
+* `--canonical-url <URL>`
+  Raw URL to the canonical `CONTRIBUTING.md`.
+  **Default:**
+  `https://raw.githubusercontent.com/cloud-gov/.github/main/CONTRIBUTING.md`
+  The tool will automatically derive `LICENSE.md` and `SECURITY.md` from the same directory.
+
+* `--limit <N>`
+  Maximum number of repositories to process.
+  **Default:** `0` → unlimited.
+
+* `--branch-prefix <PREFIX>`
+  Prefix for the branch name created on each repo.
+  **Default:** `sync-docs-`
+
+* `--audit`
+  **Audit mode**: report which repos/files need updating without making changes.
+
+---
+
+## Examples
+
+1. **Dry-run audit** for the entire organization:
+
+   ```bash
+   ./bulk_documentation_sync.py --org cloud-gov --audit
+   ```
+
+2. **Sync all repos**, creating PRs for any out-of-date or missing docs:
+
+   ```bash
+   ./bulk_documentation_sync.py --org cloud-gov
+   ```
+
+3. **Sync only the first 10 repos** (for testing):
+
+   ```bash
+   ./bulk_documentation_sync.py --org cloud-gov --limit 10
+   ```
+
+4. **Use a custom source directory** for canonicals:
+
+   ```bash
+   ./bulk_documentation_sync.py \
+     --org cloud-gov \
+     --canonical-url https://raw.githubusercontent.com/my-org/my-repo/main/docs/CONTRIBUTING.md
+   ```
+
+---
+
+## How It Works
+
+1. **Authentication**
+
+   * If `GITHUB_TOKEN` is set in the environment, it’s used directly.
+   * Otherwise, the script runs `gh auth token` and uses the returned token.
+
+2. **Fetch Canonicals**
+
+   * Downloads `CONTRIBUTING.md`, `LICENSE.md`, and `SECURITY.md` from the directory of the provided `--canonical-url`.
+   * Saves them to a temp folder and computes their SHA-256 checksums.
+
+3. **List Repositories**
+
+   * Executes a GraphQL query against `organization(login:$org).repositories`, ordered by name ascending.
+   * Paginates with `first: N, after: $cursor`, where `N` is either 100 or the remaining count.
+   * Filters out any repo that is archived, a fork, a template, or private, or that lacks a default branch.
+
+4. **Audit Determination**
+
+   * Loads (or creates) `audit_update_docs_<YYYYMMDD>.jsonl`.
+   * Skips any repo already seen in today’s audit file.
+
+5. **Per-Repo Processing**
+
+   * For each candidate repo:
+
+     * **Compute** the existing SHA of each doc file via GraphQL blob queries.
+     * **Compare** to the canonical SHA.
+     * If **all match**, logs `{"repo": "...", "status":"up-to-date"}` and moves on.
+     * Otherwise, in **audit mode** logs `{"repo":"...","status":"will_update","files_needed":[…]}`.
+     * In **normal mode**:
+
+       1. Checks for any open PR titled `Update docs: …`. If found, logs `{"status":"pr_exists"}`.
+       2. Creates a new branch `PREFIX<timestamp>-CONTRIBUTING_LICENSE_SECURITY`.
+       3. Commits all changed files in a single GraphQL `createCommitOnBranch` mutation.
+       4. Opens a PR via `createPullRequest`, with a title listing the filenames.
+       5. Logs `{"status":"pr_created","pr":"<url>","commit":"<oid>","files_changed":[…]}`.
+
+6. **Logging & Auditing**
+
+   * Every step emits a JSON event to stdout (`log_json`), suitable for piping to `jq` or ingesting into ELK/Prometheus.
+   * Every per-repo outcome is appended to today’s audit file for idempotency.
+
+---
+
+## Audit File Format
+
+* **Location:** same directory as the script, named
+  `audit_update_docs_<YYYYMMDD>.jsonl`
+
+* **Content:** one JSON object per line, for example:
+
+  ```jsonl
+  {"repo":"cloud-gov/example-repo","branch":"sync-docs-20250523120000-CONTRIBUTING_LICENSE","status":"pr_created","pr":"https://github.com/cloud-gov/example-repo/pull/123","commit":"abc123…","files_changed":["CONTRIBUTING.md","LICENSE.md"],"timestamp":"2025-05-23T12:00:05.123456+00:00"}
+  ```
+
+---
+
+## Troubleshooting
+
+* **Only 100 repos fetched?**
+  Ensure you’re running without `--limit` or with `--limit 0`. Check the `page_fetched` logs to verify pagination.
+
+* **Authentication errors**
+
+  * Set `GITHUB_TOKEN` to a valid Personal Access Token with `repo` scope.
+  * Or run `gh auth login` before invoking the script.
+
+* **GraphQL rate limits**
+  Monitor the `X-RateLimit-Remaining` header via GitHub’s API or wrap calls in backoff logic if needed.
+
+* **Script crashes on Python errors**
+
+  * Verify dependencies:
+
+    ```bash
+    pip install requests
+    ```
+  * Run `python3 --version` to confirm you’re using Python 3.8+.
+
+---
+
+## Contributing & Feedback
+
+Feel free to open issues or pull requests on this script’s repository. For major changes, please follow the same contribution workflow:
+
+1. Fork the repo.
+2. Create a feature branch.
+3. Run existing tests (if any) and verify linting.
+4. Submit a pull request for review.
+
+---
+
+*Automated by bulk\_documentation\_sync.py — keeping your organization’s docs in perfect sync!*
+````

--- a/github/bulk_update/bulk_documentation_sync.py
+++ b/github/bulk_update/bulk_documentation_sync.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+"""
+bulk_documentation_sync.py — v1.1 (2025-05-23)
+
+Description:
+    bulk_documentation_sync.py is a command-line tool that automates the
+    synchronization of key documentation files across all repositories in a
+    GitHub organization. Specifically, it handles:
+
+      • CONTRIBUTING.md
+      • LICENSE.md
+      • SECURITY.md
+
+    The script will:
+      1. Authenticate via GITHUB_TOKEN or the GitHub CLI.
+      2. Download canonical versions of the above files from a single source.
+      3. Enumerate every non-archived, non-fork, non-template, non-private repo.
+      4. Compare SHA-256 checksums of existing files against the canonical ones.
+      5. In “audit” mode, list which repos/files require updates without making
+         any changes.
+      6. In normal mode:
+         a. Skip any repo that already has an open “Update docs:” PR.
+         b. Create a new branch named
+            `<branch-prefix><timestamp>-CONTRIBUTING_LICENSE_SECURITY`
+         c. Commit all out-of-date or missing files in one atomic GraphQL mutation.
+         d. Open a PR with a title and body listing exactly which files changed.
+      7. Emit structured JSON logs for every major event (page fetch, branch
+         creation, PR creation, errors), and append one record per repo to a
+         daily audit file (`audit_update_docs_YYYYMMDD.jsonl`) so each repo is
+         only processed once per day.
+
+Usage:
+    python bulk_documentation_sync.py --org <ORG> [options]
+
+Required:
+    --org <ORG>             GitHub organization login (e.g. cloud-gov)
+
+Options:
+    --canonical-url <URL>   Raw URL to CONTRIBUTING.md. LICENSE.md and
+                            SECURITY.md are derived from the same directory.
+                            (default:
+                            https://raw.githubusercontent.com/cloud-gov/.github/main/CONTRIBUTING.md)
+    --limit <N>             Max repositories to process. 0 means unlimited.
+                            (default: 0)
+    --branch-prefix <PFX>   Prefix for created branches.
+                            (default: sync-docs-)
+    --audit                 Audit mode: list needed updates without making changes.
+    --help                  Show this help message and exit.
+
+Examples:
+    # Dry-run audit for entire org (no changes)
+    python bulk_documentation_sync.py --org cloud-gov --audit
+
+    # Synchronize all repos, creating PRs for any out-of-date docs
+    python bulk_documentation_sync.py --org cloud-gov
+
+    # Test on first 10 repos only
+    python bulk_documentation_sync.py --org cloud-gov --limit 10
+
+    # Use alternate canonical files location
+    python bulk_documentation_sync.py \
+      --org cloud-gov \
+      --canonical-url https://raw.githubusercontent.com/my-org/my-repo/main/docs/CONTRIBUTING.md
+"""
+
+import os
+import sys
+import argparse
+import base64
+import hashlib
+import json
+import logging
+import tempfile
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests
+
+# ───────────────────── Configuration ───────────────────── #
+GITHUB_API = "https://api.github.com/graphql"
+DOC_FILES = ["CONTRIBUTING.md", "LICENSE.md", "SECURITY.md"]
+PR_TITLE_PREFIX = "Update docs: "
+
+# Authentication via GITHUB_TOKEN or fallback to GH CLI
+raw_token = os.getenv("GITHUB_TOKEN")
+if raw_token:
+    TOKEN = raw_token.strip()
+else:
+    try:
+        TOKEN = subprocess.run(
+            ["gh", "auth", "token"], text=True, capture_output=True, check=True
+        ).stdout.strip()
+    except Exception:
+        print(
+            "Error: Could not obtain GitHub token. Please set GITHUB_TOKEN or run `gh auth login`.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+HEADERS = {"Authorization": f"Bearer {TOKEN}"}
+
+# Timestamps
+RUN_TS = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+RUN_DATE = datetime.now(timezone.utc).strftime("%Y%m%d")
+AUDIT_FILE = Path(f"audit_update_docs_{RUN_DATE}.jsonl")
+
+# Defaults
+DEFAULT_CANONICAL_URL = (
+    "https://raw.githubusercontent.com/cloud-gov/.github/main/CONTRIBUTING.md"
+)
+DEFAULT_BRANCH_PREFIX = "sync-docs-"
+DEFAULT_LIMIT = 0  # 0 = unlimited
+
+# ──────────────────── Structured Logging ─────────────────── #
+logger = logging.getLogger("bulk_sync")
+handler = logging.StreamHandler()
+handler.setFormatter(logging.Formatter(fmt="%(message)s"))
+logger.setLevel(logging.INFO)
+logger.addHandler(handler)
+
+
+def log_json(event: Dict[str, Any]) -> None:
+    """Emit a structured JSON log event."""
+    logger.info(json.dumps(event, default=str))
+
+
+# ───────────────────────── Helpers ───────────────────────── #
+def run_graphql(query: str, variables: Dict[str, Any]) -> Dict[str, Any]:
+    resp = requests.post(
+        GITHUB_API, json={"query": query, "variables": variables}, headers=HEADERS
+    )
+    if resp.status_code != 200:
+        raise RuntimeError(f"GraphQL HTTP {resp.status_code}: {resp.text}")
+    data = resp.json()
+    if errors := data.get("errors"):
+        raise RuntimeError(f"GraphQL errors: {errors}")
+    return data["data"]  # type: ignore
+
+
+def audit_load() -> set:
+    seen = set()
+    if AUDIT_FILE.exists():
+        for line in AUDIT_FILE.read_text().splitlines():
+            try:
+                rec = json.loads(line)
+                seen.add(rec.get("repo"))
+            except json.JSONDecodeError:
+                continue
+    return seen
+
+
+def audit_write(record: Dict[str, Any]) -> None:
+    with AUDIT_FILE.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(record, default=str) + "\n")
+
+
+# ──────────────────── Canonical Fetch ──────────────────── #
+def fetch_canonicals(base_url: str) -> Dict[str, Tuple[Path, str]]:
+    base_dir = base_url.rsplit("/", 1)[0]
+    result: Dict[str, Tuple[Path, str]] = {}
+    for fname in DOC_FILES:
+        url = f"{base_dir}/{fname}"
+        resp = requests.get(url, timeout=30)
+        resp.raise_for_status()
+        tmp = Path(tempfile.gettempdir()) / f"{fname}_{RUN_TS}"
+        tmp.write_bytes(resp.content)
+        sha = hashlib.sha256(resp.content).hexdigest()
+        result[fname] = (tmp, sha)
+        log_json({"event": "canonical_fetched", "file": fname, "sha": sha})
+    return result
+
+
+# ──────────────────── Repository Listing ──────────────────── #
+def list_repos(org: str, limit: int) -> List[Dict[str, Any]]:
+    """
+    Fetch non-archived, non-fork, non-template, non-private repos.
+    Uses cursor pagination with orderBy NAME ASC. If limit>0, stops after that many.
+    """
+    repos: List[Dict[str, Any]] = []
+    cursor: Optional[str] = None
+    remaining = limit
+    unlimited = limit == 0
+    per_page = 100
+
+    query = """
+query($org:String!, $first:Int!, $after:String) {
+  organization(login:$org) {
+    repositories(
+      first:$first, after:$after,
+      orderBy:{field:NAME, direction:ASC}
+    ) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        id nameWithOwner isArchived isFork isTemplate isPrivate
+        defaultBranchRef { name target { oid } }
+      }
+    }
+  }
+}
+"""
+    total_fetched = 0
+    while True:
+        take = per_page if unlimited else min(per_page, remaining)
+        vars = {"org": org, "first": take, "after": cursor}
+        data = run_graphql(query, vars)
+        block = data["organization"]["repositories"]
+        has_next = block["pageInfo"]["hasNextPage"]
+        log_json(
+            {
+                "event": "page_fetched",
+                "endCursor": block["pageInfo"]["endCursor"],
+                "hasNextPage": has_next,
+                "nodes_returned": len(block["nodes"]),
+            }
+        )
+        for node in block["nodes"]:
+            if any(
+                node.get(flag)
+                for flag in ("isArchived", "isFork", "isTemplate", "isPrivate")
+            ):
+                continue
+            if not node.get("defaultBranchRef"):
+                continue
+            repos.append(node)
+            total_fetched += 1
+            if not unlimited:
+                remaining -= 1
+                if remaining <= 0:
+                    log_json(
+                        {
+                            "event": "list_repos_complete",
+                            "repos_returned": total_fetched,
+                            "limit": limit,
+                        }
+                    )
+                    return repos
+        if not has_next:
+            break
+        cursor = block["pageInfo"]["endCursor"]
+
+    log_json(
+        {
+            "event": "list_repos_complete",
+            "repos_returned": total_fetched,
+            "limit": limit,
+        }
+    )
+    return repos
+
+
+# ───────────────────────── File Checks ───────────────────────── #
+def get_blob_sha(owner: str, name: str, branch: str, fname: str) -> Optional[str]:
+    blob_q = """
+query($owner:String!, $name:String!, $expr:String!) {
+  repository(owner:$owner, name:$name) {
+    object(expression:$expr) { ... on Blob { text } }
+  }
+}
+"""
+    expr = f"{branch}:{fname}"
+    try:
+        data = run_graphql(blob_q, {"owner": owner, "name": name, "expr": expr})
+        text = data["repository"]["object"]["text"]
+        return hashlib.sha256(text.encode()).hexdigest()
+    except Exception:
+        return None
+
+
+def get_existing_pr(owner: str, name: str) -> Optional[str]:
+    pr_q = """
+query($owner:String!, $name:String!) {
+  repository(owner:$owner, name:$name) {
+    pullRequests(states:OPEN, first:10) {
+      nodes { title url }
+    }
+  }
+}
+"""
+    data = run_graphql(pr_q, {"owner": owner, "name": name})
+    for pr in data["repository"]["pullRequests"]["nodes"]:
+        if pr["title"].startswith(PR_TITLE_PREFIX):
+            return pr["url"]
+    return None
+
+
+# ───────────────────────── Git Operations ───────────────────────── #
+def create_ref(repo_id: str, branch: str, base_oid: str) -> None:
+    m = """
+mutation($i:CreateRefInput!) {
+  createRef(input:$i) { ref { name } }
+}
+"""
+    inp = {"repositoryId": repo_id, "name": f"refs/heads/{branch}", "oid": base_oid}
+    run_graphql(m, {"i": inp})
+
+
+def commit_on_branch(
+    owner: str, name: str, branch: str, files: List[Path], base_oid: str
+) -> str:
+    additions = []
+    for f in files:
+        content = base64.b64encode(f.read_bytes()).decode()
+        additions.append({"path": f.name, "contents": content})
+    m = """
+mutation($i:CreateCommitOnBranchInput!) {
+  createCommitOnBranch(input:$i) { commit { oid } }
+}
+"""
+    inp = {
+        "branch": {"repositoryNameWithOwner": f"{owner}/{name}", "branchName": branch},
+        "message": {"headline": "Sync documentation files"},
+        "expectedHeadOid": base_oid,
+        "fileChanges": {"additions": additions},
+    }
+    data = run_graphql(m, {"i": inp})
+    return data["createCommitOnBranch"]["commit"]["oid"]
+
+
+def create_pull_request(repo_id: str, branch: str, base: str, files: List[str]) -> str:
+    title = PR_TITLE_PREFIX + ", ".join(files)
+    body = (
+        "This PR synchronizes the following documentation files:\n\n"
+        + "\n".join(f"- `{f}`" for f in files)
+        + "\n\n*Automated by bulk_documentation_sync.py*"
+    )
+    m = """
+mutation($i:CreatePullRequestInput!) {
+  createPullRequest(input:$i) { pullRequest { url } }
+}
+"""
+    inp = {
+        "repositoryId": repo_id,
+        "headRefName": branch,
+        "baseRefName": base,
+        "title": title,
+        "body": body,
+    }
+    data = run_graphql(m, {"i": inp})
+    return data["createPullRequest"]["pullRequest"]["url"]
+
+
+# ───────────────────────── Worker ───────────────────────── #
+def process_repo(
+    node: Dict[str, Any],
+    canonicals: Dict[str, Tuple[Path, str]],
+    branch_prefix: str,
+    audit_mode: bool,
+) -> None:
+    full = node["nameWithOwner"]
+    owner, name = full.split("/")
+    repo_id = node["id"]
+    ref = node["defaultBranchRef"]
+    base = ref["name"]
+    oid = ref["target"]["oid"]
+    branch = f"{branch_prefix}{RUN_TS}-" + "_".join(f[:-3] for f in DOC_FILES)
+    rec: Dict[str, Any] = {"repo": full, "branch": branch}
+
+    try:
+        to_update: List[Path] = []
+        missing: List[str] = []
+        for fname in DOC_FILES:
+            existing_sha = get_blob_sha(owner, name, base, fname)
+            _, canon_sha = canonicals[fname]
+            if existing_sha != canon_sha:
+                to_update.append(canonicals[fname][0])
+                missing.append(fname)
+
+        if not to_update:
+            rec["status"] = "up-to-date"
+            log_json(rec)
+        else:
+            rec["files_needed"] = missing
+            if audit_mode:
+                rec["status"] = "will_update"
+                log_json(rec)
+            else:
+                if get_existing_pr(owner, name):
+                    rec["status"] = "pr_exists"
+                    log_json(rec)
+                else:
+                    create_ref(repo_id, branch, oid)
+                    new_oid = commit_on_branch(owner, name, branch, to_update, oid)
+                    pr_url = create_pull_request(repo_id, branch, base, missing)
+                    rec.update(
+                        {
+                            "status": "pr_created",
+                            "commit": new_oid,
+                            "pr": pr_url,
+                            "files_changed": missing,
+                        }
+                    )
+                    log_json(rec)
+    except Exception as e:
+        rec.update({"status": "error", "error": str(e)})
+        log_json(rec)
+    finally:
+        rec["timestamp"] = datetime.now(timezone.utc).isoformat()
+        audit_write(rec)
+
+
+# ────────────────────────── Main ───────────────────────── #
+def main() -> None:
+    seen = audit_load()
+
+    parser = argparse.ArgumentParser(
+        description="Bulk-sync CONTRIBUTING.md, LICENSE.md, SECURITY.md"
+    )
+    parser.add_argument("--org", required=True, help="GitHub organization login")
+    parser.add_argument(
+        "--canonical-url",
+        default=DEFAULT_CANONICAL_URL,
+        help="Raw URL to canonical CONTRIBUTING.md; LICENSE/SECURITY derived",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=DEFAULT_LIMIT,
+        help="Max repos to process (0=unlimited)",
+    )
+    parser.add_argument(
+        "--branch-prefix",
+        default=DEFAULT_BRANCH_PREFIX,
+        help="Prefix for created branches",
+    )
+    parser.add_argument(
+        "--audit",
+        action="store_true",
+        help="Audit mode: list needed updates without making changes",
+    )
+    args = parser.parse_args()
+
+    canonicals = fetch_canonicals(args.canonical_url)
+    log_json({"event": "canonicals_ready", "files": list(canonicals.keys())})
+
+    repos = list_repos(args.org, args.limit)
+    to_process = [r for r in repos if r["nameWithOwner"] not in seen]
+    log_json(
+        {
+            "event": "start_processing",
+            "count": len(to_process),
+            "audit_mode": args.audit,
+        }
+    )
+
+    for node in to_process:
+        process_repo(node, canonicals, args.branch_prefix, args.audit)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Changes proposed in this pull request:
Add bulk_documentation_sync.py, a new CLI tool to automate synchronizing CONTRIBUTING.md, LICENSE.md, and SECURITY.md across all organization repositories via the GitHub GraphQL API.

Include structured JSON logging, audit mode (dry-run), unlimited pagination, existing-PR detection, and dynamic branch/PR naming.

Update the top of the script with a detailed description, usage examples, and command-line argument documentation.

### Security considerations
Minimal scope: Relies on a GitHub token with only repo read/write permissions; no other external network calls.

Read-only fetch of canonicals: Downloads only static markdown files from a trusted, organization-owned repo.

No execution of untrusted code: All changes are applied via GitHub’s GraphQL API and committed only to new branches under operator control.

