### PR TITLE
Fixed multi-org with agency arg

### DIFF
--- a/cost-estimator/estimate-costs.py
+++ b/cost-estimator/estimate-costs.py
@@ -711,6 +711,7 @@ Notes:
         "-s",
         "--spaces",
         nargs="*",
+        default=[],
         help="space names. only allowed for a single organization name",
     )
     parser.add_argument("orgs", nargs="+", help="organization names")


### PR DESCRIPTION
## Changes proposed in this pull request:
-
- running `./estimate-costs.py -a agency agency-org-a agency-org-b` resulted in:
```
Traceback (most recent call last):
  File "/Users/peterdburkholder/Projects/cloud-gov/cg-scripts/cost-estimator/./estimate-costs.py", line 757, in <module>
    main()
    ~~~~^^
  File "/Users/peterdburkholder/Projects/cloud-gov/cg-scripts/cost-estimator/./estimate-costs.py", line 723, in main
    if len(org_names) > 1 and len(space_names) > 0:
                              ~~~^^^^^^^^^^^^^
```
- This seems to fix that.

## security considerations
Safe default.
